### PR TITLE
Enhance secret media UX and seal secret links

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,103 @@
-# unworld3.0
+# Enclypse Presence Platform
 
-[Edit in StackBlitz next generation editor ⚡️](https://stackblitz.com/~/github.com/RepertoireLLC/unworld3.0)
+Enclypse is a privacy-first communications stack that combines a modular HTML front-end, a secure Node/Express backend, and Electron packaging so the entire workspace can be downloaded and executed offline. The project ships with:
+
+- Authentication, contacts, search, QR codes, and presence-aware chat views as standalone HTML modules.
+- A hardened Express backend that stores user data in SQLite, encrypts messages and attachments with libsodium, and exposes real-time presence through WebSockets.
+- Portable bootstrapping scripts and Electron packaging for a desktop-class experience out-of-the-box.
+- Media flair including Snapchat-style ephemeral messages, animated secret photo filters with on-screen motion cues, and encrypted shared albums with an in-app lightbox viewer.
+- Peer-to-peer mini-games (tic-tac-toe & trivia), an on-device AI sidekick for summaries/memes, and QR treasure hunts.
+- A constellation-driven sphere that renders animated avatars, glowing presence trails, shared secret links, and per-user theming.
+- A sealed secret-link vault that encrypts hidden rooms per participant before syncing them across the sphere.
+
+## Repository layout
+
+```
+enclypse/
+  frontend/           # Standalone HTML modules + shared assets
+  backend/            # Express server, SQLite schema, encryption helpers
+  scripts/setup.bat   # One-click bootstrap for Windows + Conda users
+electron/             # Electron entry point wrapping the HTML modules
+src/                  # Existing Vite playground (kept for rapid prototyping)
+```
+
+## Prerequisites
+
+- Node.js 20+
+- SQLite3 runtime (bundled with most platforms)
+- (Optional) Conda if you want to use the one-click `setup.bat`
+
+## Quick start
+
+Install dependencies and run the backend plus Electron shell in parallel:
+
+```bash
+npm install
+npm run enclypse
+```
+
+If the environment blocks access to the public npm registry, install dependencies manually using your preferred mirror, then re-run the commands above.
+
+The backend is exposed on **http://localhost:4000** with WebSockets on **ws://localhost:4001**. Static HTML modules are available at **http://localhost:4000/enclypse/login.html** and packaged Electron loads them locally.
+
+### Windows one-click setup
+
+```
+enclypse\scripts\setup.bat
+```
+
+The script will create a Conda environment, install both front-end and back-end dependencies, start the secure backend, and finally launch the Electron shell.
+
+## Backend API highlights
+
+- `POST /api/register` and `POST /api/login` for Argon2-hardened authentication.
+- `GET /api/presence` returns all users with live online/offline status.
+- `POST /api/messages` and `POST /api/messages/attachment` persist end-to-end encrypted payloads.
+- `GET /api/messages/:username` streams encrypted conversation history without ever decrypting messages server-side.
+- `GET /api/qr/me` and `GET /api/qr/:username` provide ready-to-scan contact sharing.
+- `GET /api/transports` and `POST /api/transports` toggle between internet messaging and the optional Bluetooth relay.
+- `GET/POST /api/preferences` manage personal themes, avatar URLs, trails, and presence chimes.
+- `GET/POST /api/albums` plus `POST /api/albums/:id/items` power encrypted shared galleries.
+- `GET/POST /api/games` and `POST /api/games/:id/move` coordinate encrypted peer mini-games.
+- `GET/POST /api/secret-links` (with per-recipient sealed keys) and `POST /api/qr/treasure` unlock secret rooms and treasure hunts around the sphere.
+
+Refer to `enclypse/frontend/common.js` and the individual HTML modules for detailed usage examples.
+
+## Bluetooth relay mode
+
+Enclypse ships with an experimental Bluetooth Low Energy transport for nearby chats. When the host computer supports BLE (and the optional `@abandonware/bleno`/`@abandonware/noble` native modules are available), users can switch their chat channel to **Bluetooth** from the chat screen. Messages remain end-to-end encrypted and travel directly between peers without Wi‑Fi. Attachments continue to require the internet channel.
+
+- Enable Bluetooth on the operating system and ensure the device is discoverable.
+- Open any conversation in `chat.html`, switch the **Channel** selector to Bluetooth, and wait for the status badge to turn green.
+- Nearby Enclypse peers advertising over BLE will receive messages even if they are offline from Wi‑Fi; conversations sync back to the primary store the next time they connect.
+
+If BLE support is not available, the selector remains on Internet and the backend gracefully reports the limitation.
+
+## Notes on encryption
+
+- Text messages are encrypted using libsodium sealed boxes (X25519 + XSalsa20-Poly1305) with per-message nonces.
+- Attachments leverage XChaCha20-Poly1305. Files are stored encrypted on disk; downloads are decrypted on-demand after authorization checks.
+- Private keys are protected using libsodium secret boxes derived from the user’s password and stored alongside Argon2id password hashes.
+- Secret link payloads are sealed for every participant using libsodium’s anonymous boxes so only invited nodes can open their portals.
+
+## Testing the WebSocket presence map
+
+1. Start the backend (`npm run backend:start`).
+2. Register two accounts via `http://localhost:4000/enclypse/register.html`.
+3. Log in on both accounts and open `sphere.html` – the nodes will glow based on each user's chosen theme, show animated avatar sprites, and draw glowing trails of recent movement.
+4. Use Ctrl/Cmd-click on two nodes to drop a shared secret link, watch constellations snap into place, and listen for optional presence chimes when a favorite contact comes online.
+5. Chat in real-time; attachments, albums, mini-games, and treasure hunts update instantly via WebSockets.
+
+## Portable builds
+
+- The Electron entry (`electron/main.js`) wraps the HTML modules for a desktop-class experience.
+- `setup.bat` orchestrates Conda environment creation, backend start-up, and Electron launch for Windows users.
+- Future installer/portable packaging can be layered on top of this structure without changes to application logic.
+
+## Troubleshooting
+
+- **Dependency mirrors:** If npm registry access is restricted, configure the `npm config set registry` command to point to an accessible mirror before running `npm install`.
+- **Database reset:** The backend auto-recreates its SQLite schema if the database file becomes corrupted. Delete `enclypse/backend/data/enclypse.sqlite` to reset state.
+- **Uploads:** Encrypted attachments are stored in `/uploads`. Clearing the directory is safe; encrypted metadata remains in SQLite.
+
+Enjoy building on Enclypse! 🚀

--- a/electron/main.js
+++ b/electron/main.js
@@ -1,0 +1,46 @@
+import { app, BrowserWindow, shell } from 'electron';
+import path from 'path';
+import url from 'url';
+import { fileURLToPath } from 'url';
+import { dirname } from 'path';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+const FRONTEND_ENTRY = process.env.ENCLYPSE_ENTRY || path.join(__dirname, '..', 'enclypse', 'frontend', 'login.html');
+
+function createWindow() {
+  const win = new BrowserWindow({
+    width: 1280,
+    height: 840,
+    backgroundColor: '#0f172a',
+    webPreferences: {
+      preload: path.join(__dirname, 'preload.js'),
+    },
+  });
+
+  win.loadURL(
+    url.format({
+      pathname: FRONTEND_ENTRY,
+      protocol: 'file:',
+      slashes: true,
+    }),
+  );
+
+  win.webContents.setWindowOpenHandler(({ url: externalUrl }) => {
+    shell.openExternal(externalUrl);
+    return { action: 'deny' };
+  });
+}
+
+app.whenReady().then(() => {
+  createWindow();
+  app.on('activate', () => {
+    if (BrowserWindow.getAllWindows().length === 0) createWindow();
+  });
+});
+
+app.on('window-all-closed', () => {
+  if (process.platform !== 'darwin') {
+    app.quit();
+  }
+});

--- a/electron/preload.js
+++ b/electron/preload.js
@@ -1,0 +1,13 @@
+import { contextBridge } from 'electron';
+import fs from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
+import { dirname } from 'path';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+const pkg = JSON.parse(fs.readFileSync(path.join(__dirname, '..', 'package.json'), 'utf8'));
+
+contextBridge.exposeInMainWorld('enclypse', {
+  version: pkg.version,
+});

--- a/enclypse/backend/bluetooth.js
+++ b/enclypse/backend/bluetooth.js
@@ -1,0 +1,263 @@
+import EventEmitter from 'events';
+import crypto from 'crypto';
+
+const SERVICE_UUID = 'c3b5d8a4-90f6-4a6e-8c6a-4f6ad3e5b1c0';
+const INBOX_UUID = '28c745d5-07e8-49f3-9f70-96d84b4f16b1';
+const OUTBOX_UUID = '836c4120-1aa6-4cae-a4c8-834807c0d64b';
+
+function shortUuid(uuid) {
+  return uuid.replace(/-/g, '');
+}
+
+function encodePayload(payload) {
+  return Buffer.from(JSON.stringify(payload), 'utf8');
+}
+
+function decodePayload(buffer) {
+  try {
+    return JSON.parse(buffer.toString('utf8'));
+  } catch (error) {
+    return null;
+  }
+}
+
+export function computeBluetoothIdentifier(username) {
+  return crypto.createHash('sha256').update(username).digest('hex').slice(0, 20);
+}
+
+class OutboxCharacteristic {
+  constructor(bleno) {
+    const { Characteristic } = bleno;
+    const self = this;
+    this._characteristic = new Characteristic({
+      uuid: OUTBOX_UUID,
+      properties: ['notify'],
+      onSubscribe(maxValueSize, updateValueCallback) {
+        self._updateValueCallback = updateValueCallback;
+      },
+      onUnsubscribe() {
+        self._updateValueCallback = null;
+      },
+    });
+    this._updateValueCallback = null;
+  }
+
+  get characteristic() {
+    return this._characteristic;
+  }
+
+  push(payload) {
+    if (this._updateValueCallback) {
+      try {
+        this._updateValueCallback(encodePayload(payload));
+      } catch (error) {
+        console.warn('Bluetooth outbox notify failed', error.message);
+      }
+    }
+  }
+}
+
+export class BluetoothRelay extends EventEmitter {
+  constructor() {
+    super();
+    this.available = false;
+    this.enabled = false;
+    this.activeContext = null;
+    this.peers = new Map();
+    this.ready = this.#initialise();
+  }
+
+  async #initialise() {
+    try {
+      const nobleModule = await import('@abandonware/noble');
+      const blenoModule = await import('@abandonware/bleno');
+      this.noble = nobleModule.default || nobleModule;
+      this.bleno = blenoModule.default || blenoModule;
+      this.available = true;
+      this.#setupNoble();
+      this.#setupBleno();
+    } catch (error) {
+      this.available = false;
+      console.warn('Bluetooth transport unavailable:', error.message);
+    }
+  }
+
+  async enableForUser({ userId, username, identifier }) {
+    await this.ready;
+    if (!this.available) throw new Error('Bluetooth stack not available');
+    this.activeContext = { userId, username, identifier };
+    this.enabled = true;
+    if (this.bleno?.state === 'poweredOn') {
+      this.#startAdvertising();
+    }
+  }
+
+  async disableForUser(userId) {
+    await this.ready;
+    if (!this.activeContext || this.activeContext.userId !== userId) return;
+    this.activeContext = null;
+    this.enabled = false;
+    if (this.bleno) {
+      try {
+        this.bleno.stopAdvertising();
+      } catch (error) {
+        console.warn('Failed to stop Bluetooth advertising', error.message);
+      }
+    }
+  }
+
+  async sendMessage({ fromIdentifier, toIdentifier, payload }) {
+    await this.ready;
+    if (!this.available) throw new Error('Bluetooth stack not available');
+    const peripheral = this.peers.get(toIdentifier);
+    if (!peripheral) {
+      throw new Error('Bluetooth peer not in range');
+    }
+    const message = {
+      ...payload,
+      transport: 'bluetooth',
+      from: fromIdentifier,
+      to: toIdentifier,
+      timestamp: new Date().toISOString(),
+    };
+    return new Promise((resolve, reject) => {
+      peripheral.connect((connectError) => {
+        if (connectError) {
+          reject(connectError);
+          return;
+        }
+        peripheral.discoverServices([shortUuid(SERVICE_UUID)], (serviceErr, services) => {
+          if (serviceErr || !services?.length) {
+            peripheral.disconnect();
+            reject(serviceErr || new Error('Bluetooth service unavailable'));
+            return;
+          }
+          const [service] = services;
+          service.discoverCharacteristics([shortUuid(INBOX_UUID)], (charErr, characteristics) => {
+            if (charErr || !characteristics?.length) {
+              peripheral.disconnect();
+              reject(charErr || new Error('Bluetooth inbox missing'));
+              return;
+            }
+            const [characteristic] = characteristics;
+            characteristic.write(encodePayload(message), false, (writeErr) => {
+              peripheral.disconnect();
+              if (writeErr) reject(writeErr);
+              else resolve(true);
+            });
+          });
+        });
+      });
+    });
+  }
+
+  pushOutbound(payload) {
+    if (this.outboxCharacteristic) {
+      this.outboxCharacteristic.push(payload);
+    }
+  }
+
+  #setupNoble() {
+    if (!this.noble) return;
+    this.noble.on('stateChange', (state) => {
+      if (state === 'poweredOn') {
+        try {
+          this.noble.startScanning([shortUuid(SERVICE_UUID)], true);
+        } catch (error) {
+          console.warn('Unable to start Bluetooth scanning', error.message);
+        }
+      } else {
+        try {
+          this.noble.stopScanning();
+        } catch (error) {
+          // ignore
+        }
+      }
+    });
+
+    this.noble.on('discover', (peripheral) => {
+      const advertisement = peripheral?.advertisement || {};
+      const hasService = (advertisement.serviceUuids || []).includes(shortUuid(SERVICE_UUID));
+      if (!hasService) return;
+      const identifier = this.#extractIdentifier(advertisement.localName);
+      if (!identifier) return;
+      this.peers.set(identifier, peripheral);
+    });
+  }
+
+  #setupBleno() {
+    if (!this.bleno) return;
+    const { Characteristic, PrimaryService } = this.bleno;
+    const self = this;
+
+    const inbox = new Characteristic({
+      uuid: INBOX_UUID,
+      properties: ['write'],
+      onWriteRequest(data, offset, withoutResponse, callback) {
+        if (offset) {
+          callback(Characteristic.RESULT_ATTR_NOT_LONG);
+          return;
+        }
+        const payload = decodePayload(data);
+        if (!payload) {
+          callback(Characteristic.RESULT_UNLIKELY_ERROR);
+          return;
+        }
+        self.#handleInbound(payload);
+        callback(Characteristic.RESULT_SUCCESS);
+      },
+    });
+
+    this.outboxCharacteristic = new OutboxCharacteristic(this.bleno);
+
+    this.service = new PrimaryService({
+      uuid: SERVICE_UUID,
+      characteristics: [inbox, this.outboxCharacteristic.characteristic],
+    });
+
+    this.bleno.on('stateChange', (state) => {
+      if (state === 'poweredOn' && this.enabled && this.activeContext) {
+        this.#startAdvertising();
+      } else if (state !== 'poweredOn') {
+        try {
+          this.bleno.stopAdvertising();
+        } catch (error) {
+          // ignore
+        }
+      }
+    });
+  }
+
+  #startAdvertising() {
+    if (!this.bleno || !this.service || !this.activeContext) return;
+    const name = `Enc-${this.activeContext.identifier.slice(0, 8)}`;
+    try {
+      this.bleno.stopAdvertising(() => {
+        this.bleno.setServices([this.service], (err) => {
+          if (err) {
+            console.warn('Failed to set Bluetooth services', err.message);
+            return;
+          }
+          this.bleno.startAdvertising(name, [SERVICE_UUID], (startErr) => {
+            if (startErr) {
+              console.warn('Bluetooth advertising error', startErr.message);
+            }
+          });
+        });
+      });
+    } catch (error) {
+      console.warn('Bluetooth advertising setup failed', error.message);
+    }
+  }
+
+  #extractIdentifier(localName = '') {
+    if (!localName.startsWith('Enc-')) return null;
+    return localName.slice(4);
+  }
+
+  #handleInbound(payload) {
+    if (!payload?.to || !this.activeContext) return;
+    if (payload.to !== this.activeContext.identifier) return;
+    this.emit('message', payload);
+  }
+}

--- a/enclypse/backend/database.js
+++ b/enclypse/backend/database.js
@@ -1,0 +1,297 @@
+import fs from 'fs';
+import path from 'path';
+import sqlite3 from 'sqlite3';
+import { fileURLToPath } from 'url';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+const dataDir = path.join(__dirname, 'data');
+const dbPath = path.join(dataDir, 'enclypse.sqlite');
+
+fs.mkdirSync(dataDir, { recursive: true });
+
+function openDatabase(fallback = false) {
+  return new sqlite3.Database(dbPath, (err) => {
+    if (err && !fallback) {
+      console.error('Database error, recreating schema', err.message);
+      fs.rmSync(dbPath, { force: true });
+      openDatabase(true);
+    } else if (err) {
+      throw err;
+    }
+  });
+}
+
+export const db = openDatabase();
+
+db.exec(`
+  PRAGMA foreign_keys = ON;
+  CREATE TABLE IF NOT EXISTS users (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    username TEXT UNIQUE NOT NULL,
+    display_name TEXT,
+    password_hash TEXT NOT NULL,
+    public_key TEXT NOT NULL,
+    private_key TEXT NOT NULL,
+    private_key_nonce TEXT NOT NULL,
+    private_key_salt TEXT NOT NULL,
+    bluetooth_identifier TEXT UNIQUE,
+    bio TEXT DEFAULT '',
+    created_at TEXT DEFAULT CURRENT_TIMESTAMP
+  );
+  CREATE TABLE IF NOT EXISTS contacts (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    user_id INTEGER NOT NULL,
+    contact_id INTEGER NOT NULL,
+    created_at TEXT DEFAULT CURRENT_TIMESTAMP,
+    UNIQUE(user_id, contact_id),
+    FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE,
+    FOREIGN KEY (contact_id) REFERENCES users(id) ON DELETE CASCADE
+  );
+  CREATE TABLE IF NOT EXISTS messages (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    sender_id INTEGER NOT NULL,
+    recipient_id INTEGER NOT NULL,
+    ciphertext TEXT,
+    nonce TEXT,
+    attachment_path TEXT,
+    attachment_nonce TEXT,
+    attachment_key TEXT,
+    metadata TEXT,
+    status TEXT DEFAULT 'sent',
+    created_at TEXT DEFAULT CURRENT_TIMESTAMP,
+    FOREIGN KEY (sender_id) REFERENCES users(id) ON DELETE CASCADE,
+    FOREIGN KEY (recipient_id) REFERENCES users(id) ON DELETE CASCADE
+  );
+  CREATE TABLE IF NOT EXISTS sessions (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    user_id INTEGER NOT NULL,
+    token TEXT UNIQUE NOT NULL,
+    created_at TEXT DEFAULT CURRENT_TIMESTAMP,
+    expires_at TEXT NOT NULL,
+    FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE
+  );
+  CREATE TABLE IF NOT EXISTS ephemeral_views (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    message_id INTEGER NOT NULL,
+    viewer_id INTEGER NOT NULL,
+    viewed_at TEXT DEFAULT CURRENT_TIMESTAMP,
+    FOREIGN KEY (message_id) REFERENCES messages(id) ON DELETE CASCADE,
+    FOREIGN KEY (viewer_id) REFERENCES users(id) ON DELETE CASCADE
+  );
+  CREATE TABLE IF NOT EXISTS message_unlocks (
+    message_id INTEGER NOT NULL,
+    user_id INTEGER NOT NULL,
+    unlocked_at TEXT DEFAULT CURRENT_TIMESTAMP,
+    PRIMARY KEY (message_id, user_id),
+    FOREIGN KEY (message_id) REFERENCES messages(id) ON DELETE CASCADE,
+    FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE
+  );
+  CREATE TABLE IF NOT EXISTS albums (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    owner_id INTEGER NOT NULL,
+    name TEXT NOT NULL,
+    theme TEXT DEFAULT 'default',
+    created_at TEXT DEFAULT CURRENT_TIMESTAMP,
+    FOREIGN KEY (owner_id) REFERENCES users(id) ON DELETE CASCADE
+  );
+  CREATE TABLE IF NOT EXISTS album_members (
+    album_id INTEGER NOT NULL,
+    user_id INTEGER NOT NULL,
+    role TEXT DEFAULT 'viewer',
+    created_at TEXT DEFAULT CURRENT_TIMESTAMP,
+    PRIMARY KEY (album_id, user_id),
+    FOREIGN KEY (album_id) REFERENCES albums(id) ON DELETE CASCADE,
+    FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE
+  );
+  CREATE TABLE IF NOT EXISTS album_items (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    album_id INTEGER NOT NULL,
+    uploader_id INTEGER NOT NULL,
+    ciphertext TEXT NOT NULL,
+    nonce TEXT NOT NULL,
+    description TEXT DEFAULT '',
+    created_at TEXT DEFAULT CURRENT_TIMESTAMP,
+    FOREIGN KEY (album_id) REFERENCES albums(id) ON DELETE CASCADE,
+    FOREIGN KEY (uploader_id) REFERENCES users(id) ON DELETE CASCADE
+  );
+  CREATE TABLE IF NOT EXISTS chat_games (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    type TEXT NOT NULL,
+    creator_id INTEGER NOT NULL,
+    opponent_id INTEGER NOT NULL,
+    state TEXT NOT NULL,
+    status TEXT DEFAULT 'active',
+    created_at TEXT DEFAULT CURRENT_TIMESTAMP,
+    updated_at TEXT DEFAULT CURRENT_TIMESTAMP,
+    FOREIGN KEY (creator_id) REFERENCES users(id) ON DELETE CASCADE,
+    FOREIGN KEY (opponent_id) REFERENCES users(id) ON DELETE CASCADE
+  );
+  CREATE TABLE IF NOT EXISTS user_preferences (
+    user_id INTEGER PRIMARY KEY,
+    theme TEXT DEFAULT 'default',
+    sound_enabled INTEGER DEFAULT 0,
+    sound_contact TEXT DEFAULT '',
+    ai_sidekick INTEGER DEFAULT 0,
+    avatar TEXT DEFAULT '',
+    trails_enabled INTEGER DEFAULT 1,
+    created_at TEXT DEFAULT CURRENT_TIMESTAMP,
+    updated_at TEXT DEFAULT CURRENT_TIMESTAMP,
+    FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE
+  );
+  CREATE TABLE IF NOT EXISTS presence_trails (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    user_id INTEGER NOT NULL,
+    position TEXT NOT NULL,
+    recorded_at TEXT DEFAULT CURRENT_TIMESTAMP,
+    FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE
+  );
+  CREATE TABLE IF NOT EXISTS constellations (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    owner_id INTEGER NOT NULL,
+    name TEXT NOT NULL,
+    style TEXT DEFAULT 'default',
+    created_at TEXT DEFAULT CURRENT_TIMESTAMP,
+    FOREIGN KEY (owner_id) REFERENCES users(id) ON DELETE CASCADE
+  );
+  CREATE TABLE IF NOT EXISTS constellation_links (
+    constellation_id INTEGER NOT NULL,
+    from_user INTEGER NOT NULL,
+    to_user INTEGER NOT NULL,
+    created_at TEXT DEFAULT CURRENT_TIMESTAMP,
+    PRIMARY KEY (constellation_id, from_user, to_user),
+    FOREIGN KEY (constellation_id) REFERENCES constellations(id) ON DELETE CASCADE,
+    FOREIGN KEY (from_user) REFERENCES users(id) ON DELETE CASCADE,
+    FOREIGN KEY (to_user) REFERENCES users(id) ON DELETE CASCADE
+  );
+  CREATE TABLE IF NOT EXISTS secret_links (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    owner_id INTEGER NOT NULL,
+    label TEXT NOT NULL,
+    cipher TEXT NOT NULL,
+    nonce TEXT NOT NULL,
+    sealed_keys TEXT,
+    audience TEXT DEFAULT '',
+    expires_at TEXT,
+    created_at TEXT DEFAULT CURRENT_TIMESTAMP,
+    FOREIGN KEY (owner_id) REFERENCES users(id) ON DELETE CASCADE
+  );
+  CREATE TABLE IF NOT EXISTS qr_treasures (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    creator_id INTEGER NOT NULL,
+    code TEXT NOT NULL,
+    hint TEXT DEFAULT '',
+    payload TEXT NOT NULL,
+    expires_at TEXT,
+    created_at TEXT DEFAULT CURRENT_TIMESTAMP,
+    FOREIGN KEY (creator_id) REFERENCES users(id) ON DELETE CASCADE
+  );
+  CREATE TABLE IF NOT EXISTS qr_claims (
+    treasure_id INTEGER NOT NULL,
+    user_id INTEGER NOT NULL,
+    claimed_at TEXT DEFAULT CURRENT_TIMESTAMP,
+    PRIMARY KEY (treasure_id, user_id),
+    FOREIGN KEY (treasure_id) REFERENCES qr_treasures(id) ON DELETE CASCADE,
+    FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE
+  );
+`, (err) => {
+  if (err) {
+    console.error('Failed to initialize schema', err);
+  }
+});
+
+db.all('PRAGMA table_info(users)', (err, rows) => {
+  if (err) {
+    console.error('Failed to inspect users table', err);
+    return;
+  }
+  const hasBluetooth = rows.some((column) => column.name === 'bluetooth_identifier');
+  if (!hasBluetooth) {
+    db.run('ALTER TABLE users ADD COLUMN bluetooth_identifier TEXT UNIQUE', (alterErr) => {
+      if (alterErr) {
+        console.error('Failed to add bluetooth_identifier column', alterErr);
+      }
+    });
+  }
+  const hasBio = rows.some((column) => column.name === 'bio');
+  if (!hasBio) {
+    db.run('ALTER TABLE users ADD COLUMN bio TEXT DEFAULT ""', (alterErr) => {
+      if (alterErr) {
+        console.error('Failed to add bio column', alterErr);
+      }
+    });
+  }
+});
+
+db.all('PRAGMA table_info(messages)', (err, rows) => {
+  if (err) {
+    console.error('Failed to inspect messages table', err);
+    return;
+  }
+  const hasMetadata = rows.some((column) => column.name === 'metadata');
+  if (!hasMetadata) {
+    db.run('ALTER TABLE messages ADD COLUMN metadata TEXT', (alterErr) => {
+      if (alterErr) {
+        console.error('Failed to add metadata column', alterErr);
+      }
+    });
+  }
+});
+
+db.all('PRAGMA table_info(secret_links)', (err, rows) => {
+  if (err) {
+    console.error('Failed to inspect secret_links table', err);
+    return;
+  }
+  const hasAudience = rows.some((column) => column.name === 'audience');
+  if (!hasAudience) {
+    db.run('ALTER TABLE secret_links ADD COLUMN audience TEXT DEFAULT ""', (alterErr) => {
+      if (alterErr) {
+        console.error('Failed to add audience column', alterErr);
+      }
+    });
+  }
+  const hasSealedKeys = rows.some((column) => column.name === 'sealed_keys');
+  if (!hasSealedKeys) {
+    db.run('ALTER TABLE secret_links ADD COLUMN sealed_keys TEXT', (alterErr) => {
+      if (alterErr) {
+        console.error('Failed to add sealed_keys column', alterErr);
+      }
+    });
+  }
+});
+
+export function run(query, params = []) {
+  return new Promise((resolve, reject) => {
+    db.run(query, params, function runCallback(err) {
+      if (err) reject(err);
+      else resolve(this);
+    });
+  });
+}
+
+export function get(query, params = []) {
+  return new Promise((resolve, reject) => {
+    db.get(query, params, (err, row) => {
+      if (err) reject(err);
+      else resolve(row);
+    });
+  });
+}
+
+export function all(query, params = []) {
+  return new Promise((resolve, reject) => {
+    db.all(query, params, (err, rows) => {
+      if (err) reject(err);
+      else resolve(rows);
+    });
+  });
+}
+
+export const paths = {
+  dataDir,
+  uploadsDir: path.resolve(__dirname, '../../uploads'),
+};
+
+fs.mkdirSync(paths.uploadsDir, { recursive: true });

--- a/enclypse/backend/package.json
+++ b/enclypse/backend/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "enclypse-backend",
+  "version": "1.0.0",
+  "type": "module",
+  "main": "server.js",
+  "scripts": {
+    "start": "node server.js"
+  },
+  "dependencies": {
+    "@abandonware/bleno": "^1.2.0",
+    "@abandonware/noble": "^1.9.2-15",
+    "argon2": "^0.40.1",
+    "cors": "^2.8.5",
+    "dotenv": "^16.4.5",
+    "express": "^4.19.2",
+    "libsodium-wrappers-sumo": "^0.7.13",
+    "multer": "^1.4.5-lts.1",
+    "qrcode": "^1.5.3",
+    "sqlite3": "^5.1.7",
+    "ws": "^8.18.0"
+  }
+}

--- a/enclypse/backend/server.js
+++ b/enclypse/backend/server.js
@@ -1,0 +1,1169 @@
+import 'dotenv/config';
+import express from 'express';
+import cors from 'cors';
+import crypto from 'crypto';
+import multer from 'multer';
+import fs from 'fs';
+import path from 'path';
+import argon2 from 'argon2';
+import sodium from 'libsodium-wrappers-sumo';
+import { fileURLToPath } from 'url';
+import http from 'http';
+import { WebSocketServer } from 'ws';
+import QRCode from 'qrcode';
+
+import { run, get, all, paths } from './database.js';
+import { BluetoothRelay, computeBluetoothIdentifier } from './bluetooth.js';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+await sodium.ready;
+
+const app = express();
+app.use(cors());
+app.use(express.json({ limit: '4mb' }));
+
+const upload = multer({ storage: multer.memoryStorage() });
+
+const SESSION_TTL = 1000 * 60 * 60 * 24 * 7;
+
+const server = http.createServer(app);
+const wss = new WebSocketServer({ port: 4001 });
+
+const bluetoothRelay = new BluetoothRelay();
+const transportSelections = new Map(); // userId -> transport string
+const onlineUsers = new Map(); // userId -> { username, displayName, sockets: Set<WebSocket> }
+const defaultPreferences = {
+  theme: 'default',
+  soundEnabled: false,
+  soundContact: '',
+  aiSidekick: false,
+  avatar: '',
+  trailsEnabled: true,
+};
+const MAX_TRAIL_POINTS = 12;
+
+function parseMetadata(raw) {
+  if (!raw) return {};
+  try {
+    const value = JSON.parse(raw);
+    return value && typeof value === 'object' ? value : {};
+  } catch (error) {
+    console.warn('Unable to parse metadata payload', error);
+    return {};
+  }
+}
+
+async function getUserPreferences(userId) {
+  const row = await get('SELECT * FROM user_preferences WHERE user_id = ?', [userId]);
+  if (!row) return { ...defaultPreferences };
+  return {
+    theme: row.theme || defaultPreferences.theme,
+    soundEnabled: Boolean(row.sound_enabled),
+    soundContact: row.sound_contact || '',
+    aiSidekick: Boolean(row.ai_sidekick),
+    avatar: row.avatar || '',
+    trailsEnabled: row.trails_enabled === null ? defaultPreferences.trailsEnabled : Boolean(row.trails_enabled),
+  };
+}
+
+async function upsertUserPreferences(userId, updates) {
+  const current = await get('SELECT * FROM user_preferences WHERE user_id = ?', [userId]);
+  const payload = {
+    theme: updates.theme ?? current?.theme ?? defaultPreferences.theme,
+    sound_enabled:
+      updates.soundEnabled !== undefined ? (updates.soundEnabled ? 1 : 0) : current?.sound_enabled ?? (defaultPreferences.soundEnabled ? 1 : 0),
+    sound_contact: updates.soundContact ?? current?.sound_contact ?? defaultPreferences.soundContact,
+    ai_sidekick:
+      updates.aiSidekick !== undefined ? (updates.aiSidekick ? 1 : 0) : current?.ai_sidekick ?? (defaultPreferences.aiSidekick ? 1 : 0),
+    avatar: updates.avatar ?? current?.avatar ?? defaultPreferences.avatar,
+    trails_enabled:
+      updates.trailsEnabled !== undefined
+        ? (updates.trailsEnabled ? 1 : 0)
+        : current?.trails_enabled ?? (defaultPreferences.trailsEnabled ? 1 : 0),
+  };
+
+  if (current) {
+    await run(
+      'UPDATE user_preferences SET theme = ?, sound_enabled = ?, sound_contact = ?, ai_sidekick = ?, avatar = ?, trails_enabled = ?, updated_at = CURRENT_TIMESTAMP WHERE user_id = ?',
+      [payload.theme, payload.sound_enabled, payload.sound_contact, payload.ai_sidekick, payload.avatar, payload.trails_enabled, userId],
+    );
+  } else {
+    await run(
+      'INSERT INTO user_preferences (user_id, theme, sound_enabled, sound_contact, ai_sidekick, avatar, trails_enabled) VALUES (?, ?, ?, ?, ?, ?, ?)',
+      [userId, payload.theme, payload.sound_enabled, payload.sound_contact, payload.ai_sidekick, payload.avatar, payload.trails_enabled],
+    );
+  }
+  return getUserPreferences(userId);
+}
+
+async function recordTrail(userId, tag = 'presence') {
+  try {
+    const angle = (Date.now() % 3600) / 10;
+    const radius = 1.5 + ((userId % 7) * 0.11);
+    const entry = {
+      tag,
+      at: new Date().toISOString(),
+      x: Math.cos(angle) * radius,
+      y: Math.sin(angle) * radius,
+      z: Math.sin(angle / 2) * radius * 0.6,
+    };
+    await run('INSERT INTO presence_trails (user_id, position) VALUES (?, ?)', [userId, JSON.stringify(entry)]);
+    await run(
+      'DELETE FROM presence_trails WHERE id NOT IN (SELECT id FROM presence_trails WHERE user_id = ? ORDER BY recorded_at DESC LIMIT ?)',
+      [userId, MAX_TRAIL_POINTS],
+    );
+  } catch (error) {
+    console.warn('Failed to record trail', error);
+  }
+}
+
+async function getConstellationsSnapshot() {
+  const constellations = await all(
+    `SELECT constellations.*, users.username AS owner_username
+     FROM constellations
+     JOIN users ON users.id = constellations.owner_id
+     ORDER BY constellations.created_at DESC`,
+  );
+  if (!constellations.length) return [];
+  const links = await all(
+    `SELECT constellation_links.constellation_id, from_user.username AS from_username, to_user.username AS to_username
+     FROM constellation_links
+     JOIN users AS from_user ON from_user.id = constellation_links.from_user
+     JOIN users AS to_user ON to_user.id = constellation_links.to_user`,
+  );
+  return constellations.map((constellation) => ({
+    id: constellation.id,
+    name: constellation.name,
+    style: constellation.style,
+    owner: constellation.owner_username,
+    links: links
+      .filter((link) => link.constellation_id === constellation.id)
+      .map((link) => ({ from: link.from_username, to: link.to_username })),
+  }));
+}
+
+bluetoothRelay.on('message', async (payload) => {
+  if (!payload?.from || !payload?.to || !payload.ciphertext || !payload.nonce) return;
+  try {
+    const sender = await get('SELECT id, username FROM users WHERE bluetooth_identifier = ?', [payload.from]);
+    const recipient = await get('SELECT id, username FROM users WHERE bluetooth_identifier = ?', [payload.to]);
+    if (!sender || !recipient) return;
+    const result = await run(
+      'INSERT INTO messages (sender_id, recipient_id, ciphertext, nonce, status) VALUES (?, ?, ?, ?, ?)',
+      [sender.id, recipient.id, payload.ciphertext, payload.nonce, 'received-bluetooth'],
+    );
+    notifyMessage(recipient.id, { from: sender.username, messageId: result.lastID });
+    await recordTrail(sender.id, 'bluetooth');
+    await recordTrail(recipient.id, 'bluetooth');
+  } catch (error) {
+    console.error('Failed to persist Bluetooth message', error);
+  }
+});
+
+async function getPresenceSnapshot() {
+  const users = await all('SELECT id, username, display_name FROM users ORDER BY username');
+  const trails = await all(
+    `SELECT presence_trails.user_id, presence_trails.position, presence_trails.recorded_at, users.username
+     FROM presence_trails
+     JOIN users ON users.id = presence_trails.user_id
+     ORDER BY presence_trails.recorded_at DESC`,
+  );
+  const trailMap = {};
+  for (const entry of trails) {
+    const payload = parseMetadata(entry.position) || {};
+    if (!trailMap[entry.username]) trailMap[entry.username] = [];
+    trailMap[entry.username].push({ ...payload, recordedAt: entry.recorded_at });
+  }
+  const preferencesEntries = await Promise.all(
+    users.map(async (user) => [user.username, await getUserPreferences(user.id)]),
+  );
+  const preferences = Object.fromEntries(preferencesEntries);
+  const constellations = await getConstellationsSnapshot();
+  return {
+    users: users.map((user) => ({
+      username: user.username,
+      displayName: user.display_name,
+      online: onlineUsers.has(user.id),
+    })),
+    trails: trailMap,
+    constellations,
+    preferences,
+    generatedAt: new Date().toISOString(),
+  };
+}
+
+async function broadcastPresence() {
+  const payload = await getPresenceSnapshot();
+  for (const entry of onlineUsers.values()) {
+    for (const socket of entry.sockets) {
+      safeSend(socket, { type: 'presence:update', payload });
+    }
+  }
+}
+
+function safeSend(socket, message) {
+  if (socket.readyState === 1) {
+    socket.send(JSON.stringify(message));
+  }
+}
+
+async function authenticateToken(token) {
+  if (!token) return null;
+  const session = await get(
+    'SELECT sessions.*, users.username, users.display_name, users.bluetooth_identifier FROM sessions JOIN users ON users.id = sessions.user_id WHERE token = ? AND datetime(expires_at) > datetime("now")',
+    [token],
+  );
+  return session || null;
+}
+
+async function registerSession(userId) {
+  const token = crypto.randomBytes(48).toString('hex');
+  const expires = new Date(Date.now() + SESSION_TTL).toISOString();
+  await run('INSERT INTO sessions (user_id, token, expires_at) VALUES (?, ?, ?)', [userId, token, expires]);
+  return token;
+}
+
+function authMiddleware(req, res, next) {
+  const header = req.headers.authorization || '';
+  const [, token] = header.split(' ');
+  authenticateToken(token)
+    .then((session) => {
+      if (!session) {
+        res.status(401).json({ error: 'Unauthorized' });
+        return;
+      }
+      req.session = session;
+      req.user = {
+        id: session.user_id,
+        username: session.username,
+        displayName: session.display_name,
+        bluetoothIdentifier: session.bluetooth_identifier,
+      };
+      next();
+    })
+    .catch((err) => {
+      console.error(err);
+      res.status(500).json({ error: 'Authentication error' });
+    });
+}
+
+app.post('/api/register', async (req, res) => {
+  try {
+    const { username, password, displayName, publicKey, privateKey } = req.body;
+    if (!username || !password || !publicKey || !privateKey) {
+      return res.status(400).json({ error: 'Missing fields' });
+    }
+    const lower = username.toLowerCase();
+    const bluetoothIdentifier = computeBluetoothIdentifier(lower);
+    const existing = await get('SELECT id FROM users WHERE username = ?', [lower]);
+    if (existing) {
+      return res.status(400).json({ error: 'Username already taken' });
+    }
+    const passwordHash = await argon2.hash(password, { type: argon2.argon2id });
+    const salt = sodium.randombytes_buf(sodium.crypto_pwhash_SALTBYTES);
+    const nonce = sodium.randombytes_buf(sodium.crypto_secretbox_NONCEBYTES);
+    const key = sodium.crypto_pwhash(32, password, salt, sodium.crypto_pwhash_OPSLIMIT_INTERACTIVE, sodium.crypto_pwhash_MEMLIMIT_INTERACTIVE, sodium.crypto_pwhash_ALG_DEFAULT);
+    const privateKeyBytes = sodium.from_base64(privateKey);
+    const cipher = sodium.crypto_secretbox_easy(privateKeyBytes, nonce, key);
+    await run(
+      'INSERT INTO users (username, display_name, password_hash, public_key, private_key, private_key_nonce, private_key_salt, bluetooth_identifier) VALUES (?, ?, ?, ?, ?, ?, ?, ?)',
+      [
+        lower,
+        displayName || '',
+        passwordHash,
+        publicKey,
+        sodium.to_base64(cipher),
+        sodium.to_base64(nonce),
+        sodium.to_base64(salt),
+        bluetoothIdentifier,
+      ],
+    );
+    res.json({ success: true });
+  } catch (error) {
+    console.error(error);
+    res.status(500).json({ error: 'Registration failed' });
+  }
+});
+
+app.post('/api/login', async (req, res) => {
+  try {
+    const { username, password } = req.body;
+    if (!username || !password) return res.status(400).json({ error: 'Missing credentials' });
+    const user = await get('SELECT * FROM users WHERE username = ?', [username.toLowerCase()]);
+    if (!user) return res.status(401).json({ error: 'Invalid credentials' });
+    const valid = await argon2.verify(user.password_hash, password);
+    if (!valid) return res.status(401).json({ error: 'Invalid credentials' });
+    let bluetoothIdentifier = user.bluetooth_identifier;
+    if (!bluetoothIdentifier) {
+      bluetoothIdentifier = computeBluetoothIdentifier(user.username);
+      await run('UPDATE users SET bluetooth_identifier = ? WHERE id = ?', [bluetoothIdentifier, user.id]);
+    }
+    const key = sodium.crypto_pwhash(
+      32,
+      password,
+      sodium.from_base64(user.private_key_salt),
+      sodium.crypto_pwhash_OPSLIMIT_INTERACTIVE,
+      sodium.crypto_pwhash_MEMLIMIT_INTERACTIVE,
+      sodium.crypto_pwhash_ALG_DEFAULT,
+    );
+    const privateKeyBytes = sodium.crypto_secretbox_open_easy(
+      sodium.from_base64(user.private_key),
+      sodium.from_base64(user.private_key_nonce),
+      key,
+    );
+    const token = await registerSession(user.id);
+    const preferences = await getUserPreferences(user.id);
+    res.json({
+      token,
+      user: {
+        id: user.id,
+        username: user.username,
+        displayName: user.display_name,
+        publicKey: user.public_key,
+        bluetoothIdentifier,
+      },
+      privateKey: sodium.to_base64(privateKeyBytes),
+      preferences,
+    });
+  } catch (error) {
+    console.error(error);
+    res.status(500).json({ error: 'Login failed' });
+  }
+});
+
+app.post('/api/logout', authMiddleware, async (req, res) => {
+  await run('DELETE FROM sessions WHERE id = ?', [req.session.id]);
+  transportSelections.delete(req.user.id);
+  bluetoothRelay.disableForUser(req.user.id).catch(() => {});
+  res.json({ success: true });
+});
+
+app.get('/api/me', authMiddleware, async (req, res) => {
+  const user = await get('SELECT id, username, display_name, bio, created_at, bluetooth_identifier FROM users WHERE id = ?', [req.user.id]);
+  const preferences = await getUserPreferences(req.user.id);
+  res.json({
+    username: user.username,
+    displayName: user.display_name,
+    bio: user.bio,
+    createdAt: user.created_at,
+    online: onlineUsers.has(user.id),
+    bluetoothIdentifier: user.bluetooth_identifier,
+    preferences,
+  });
+});
+
+app.get('/api/preferences', authMiddleware, async (req, res) => {
+  const preferences = await getUserPreferences(req.user.id);
+  res.json({ preferences });
+});
+
+app.post('/api/preferences', authMiddleware, async (req, res) => {
+  const { theme, soundEnabled, soundContact, aiSidekick, avatar, trailsEnabled } = req.body || {};
+  const preferences = await upsertUserPreferences(req.user.id, {
+    theme,
+    soundEnabled,
+    soundContact,
+    aiSidekick,
+    avatar,
+    trailsEnabled,
+  });
+  await recordTrail(req.user.id, 'preference-update');
+  broadcastPresence();
+  res.json({ preferences });
+});
+
+app.get('/api/transports', authMiddleware, (req, res) => {
+  res.json({
+    active: transportSelections.get(req.user.id) || 'internet',
+    available: {
+      bluetooth: bluetoothRelay.available,
+    },
+    bluetoothIdentifier: req.user.bluetoothIdentifier || null,
+  });
+});
+
+app.post('/api/transports', authMiddleware, async (req, res) => {
+  const { transport } = req.body || {};
+  if (!['internet', 'bluetooth'].includes(transport)) {
+    return res.status(400).json({ error: 'Invalid transport option' });
+  }
+  if (transport === 'bluetooth') {
+    try {
+      let identifier = req.user.bluetoothIdentifier;
+      if (!identifier) {
+        identifier = computeBluetoothIdentifier(req.user.username);
+        await run('UPDATE users SET bluetooth_identifier = ? WHERE id = ?', [identifier, req.user.id]);
+        req.user.bluetoothIdentifier = identifier;
+      }
+      await bluetoothRelay.enableForUser({
+        userId: req.user.id,
+        username: req.user.username,
+        identifier,
+      });
+    } catch (error) {
+      return res.status(503).json({ error: `Bluetooth unavailable: ${error.message}` });
+    }
+  } else {
+    await bluetoothRelay.disableForUser(req.user.id);
+  }
+  transportSelections.set(req.user.id, transport);
+  res.json({ success: true, active: transport });
+});
+
+app.get('/api/users/:username', authMiddleware, async (req, res) => {
+  const user = await get('SELECT id, username, display_name, public_key, bio, created_at, bluetooth_identifier FROM users WHERE username = ?', [req.params.username.toLowerCase()]);
+  if (!user) return res.status(404).json({ error: 'User not found' });
+  res.json({
+    username: user.username,
+    displayName: user.display_name,
+    publicKey: user.public_key,
+    bio: user.bio,
+    createdAt: user.created_at,
+    online: onlineUsers.has(user.id),
+    bluetoothIdentifier: user.bluetooth_identifier,
+  });
+});
+
+app.get('/api/presence', authMiddleware, async (req, res) => {
+  const payload = await getPresenceSnapshot();
+  res.json(payload);
+});
+
+app.get('/api/contacts', authMiddleware, async (req, res) => {
+  const contacts = await all(
+    `SELECT users.id, users.username, users.display_name
+     FROM contacts
+     JOIN users ON users.id = contacts.contact_id
+     WHERE contacts.user_id = ?
+     ORDER BY users.display_name COLLATE NOCASE`,
+    [req.user.id],
+  );
+  const unique = contacts.reduce((acc, user) => {
+    acc[user.username] = user;
+    return acc;
+  }, {});
+  const list = Object.values(unique);
+  res.json({
+    total: list.length,
+    onlineCount: list.filter((c) => onlineUsers.has(c.id)).length,
+    contacts: list.map((c) => ({
+      username: c.username,
+      displayName: c.display_name,
+      online: onlineUsers.has(c.id),
+    })),
+  });
+});
+
+app.post('/api/contacts', authMiddleware, async (req, res) => {
+  const { username } = req.body;
+  const target = await get('SELECT id FROM users WHERE username = ?', [username?.toLowerCase?.()]);
+  if (!target) return res.status(404).json({ error: 'User not found' });
+  if (target.id === req.user.id) return res.status(400).json({ error: 'Cannot add yourself' });
+  await run('INSERT OR IGNORE INTO contacts (user_id, contact_id) VALUES (?, ?)', [req.user.id, target.id]);
+  await run('INSERT OR IGNORE INTO contacts (user_id, contact_id) VALUES (?, ?)', [target.id, req.user.id]);
+  res.json({ success: true });
+});
+
+app.get('/api/search', authMiddleware, async (req, res) => {
+  const query = `%${(req.query.query || '').toLowerCase()}%`;
+  const results = await all(
+    `SELECT id, username, display_name
+     FROM users
+     WHERE username LIKE ? OR display_name LIKE ?
+     ORDER BY display_name COLLATE NOCASE
+     LIMIT 20`,
+    [query, query],
+  );
+  res.json({
+    results: results.map((user) => ({
+      username: user.username,
+      displayName: user.display_name,
+      online: onlineUsers.has(user.id),
+    })),
+  });
+});
+
+app.post('/api/messages', authMiddleware, async (req, res) => {
+  const { to, ciphertext, nonce, transport, options } = req.body;
+  const recipient = await get('SELECT id, username, bluetooth_identifier FROM users WHERE username = ?', [to?.toLowerCase?.()]);
+  if (!recipient) return res.status(404).json({ error: 'Recipient not found' });
+  const channel = transport === 'bluetooth' ? 'bluetooth' : 'internet';
+  let status = 'sent';
+  const messageOptions = options && typeof options === 'object' ? options : {};
+  const metadata = { transport: channel };
+  if (messageOptions.ephemeral?.enabled) {
+    metadata.ephemeral = {
+      enabled: true,
+      viewLimit: Number(messageOptions.ephemeral.viewLimit) || 1,
+      expiresSeconds: Number(messageOptions.ephemeral.expiresSeconds) || null,
+    };
+  }
+  if (messageOptions.secretLink?.cipher && messageOptions.secretLink?.nonce) {
+    metadata.secretLink = {
+      label: messageOptions.secretLink.label || 'Secret',
+      cipher: messageOptions.secretLink.cipher,
+      nonce: messageOptions.secretLink.nonce,
+      expiresAt: messageOptions.secretLink.expiresAt || null,
+    };
+  }
+  if (channel === 'bluetooth') {
+    if (!bluetoothRelay.available) {
+      return res.status(503).json({ error: 'Bluetooth transport is not available on this system' });
+    }
+    try {
+      let senderIdentifier = req.user.bluetoothIdentifier;
+      if (!senderIdentifier) {
+        senderIdentifier = computeBluetoothIdentifier(req.user.username);
+        await run('UPDATE users SET bluetooth_identifier = ? WHERE id = ?', [senderIdentifier, req.user.id]);
+        req.user.bluetoothIdentifier = senderIdentifier;
+      }
+      let recipientIdentifier = recipient.bluetooth_identifier;
+      if (!recipientIdentifier) {
+        recipientIdentifier = computeBluetoothIdentifier(recipient.username);
+        await run('UPDATE users SET bluetooth_identifier = ? WHERE id = ?', [recipientIdentifier, recipient.id]);
+      }
+      await bluetoothRelay.sendMessage({
+        fromIdentifier: senderIdentifier,
+        toIdentifier: recipientIdentifier,
+        payload: { ciphertext, nonce },
+      });
+      status = 'delivered-bluetooth';
+    } catch (error) {
+      return res.status(503).json({ error: `Bluetooth delivery failed: ${error.message}` });
+    }
+  }
+  const result = await run(
+    'INSERT INTO messages (sender_id, recipient_id, ciphertext, nonce, status, metadata) VALUES (?, ?, ?, ?, ?, ?)',
+    [req.user.id, recipient.id, ciphertext, nonce, status, JSON.stringify(metadata)],
+  );
+  notifyMessage(recipient.id, { from: req.user.username, messageId: result.lastID });
+  await recordTrail(req.user.id, 'chat');
+  await recordTrail(recipient.id, 'chat');
+  res.json({ success: true, id: result.lastID, status, transport: channel });
+});
+
+app.post('/api/messages/attachment', authMiddleware, upload.single('file'), async (req, res) => {
+  if (!req.file) return res.status(400).json({ error: 'Missing file' });
+  const { to } = req.body;
+  const recipient = await get('SELECT id FROM users WHERE username = ?', [to?.toLowerCase?.()]);
+  if (!recipient) return res.status(404).json({ error: 'Recipient not found' });
+  let metadata = { attachment: true };
+  if (req.body.options) {
+    try {
+      const parsed = JSON.parse(req.body.options);
+      if (parsed?.secretFilter?.type) {
+        metadata.secretFilter = { type: parsed.secretFilter.type, requiresInteraction: true };
+      }
+      if (parsed?.ephemeral?.enabled) {
+        metadata.ephemeral = {
+          enabled: true,
+          viewLimit: Number(parsed.ephemeral.viewLimit) || 1,
+          expiresSeconds: Number(parsed.ephemeral.expiresSeconds) || null,
+        };
+      }
+    } catch (error) {
+      console.warn('Failed to parse attachment metadata', error);
+    }
+  }
+  const key = sodium.randombytes_buf(sodium.crypto_aead_xchacha20poly1305_ietf_KEYBYTES);
+  const nonce = sodium.randombytes_buf(sodium.crypto_aead_xchacha20poly1305_ietf_NPUBBYTES);
+  const ciphertext = sodium.crypto_aead_xchacha20poly1305_ietf_encrypt(req.file.buffer, null, null, nonce, key);
+  const fileId = crypto.randomBytes(16).toString('hex');
+  const filePath = path.join(paths.uploadsDir, `${fileId}.enc`);
+  fs.writeFileSync(filePath, Buffer.from(ciphertext));
+  const result = await run(
+    'INSERT INTO messages (sender_id, recipient_id, attachment_path, attachment_nonce, attachment_key, status, metadata) VALUES (?, ?, ?, ?, ?, ?, ?)',
+    [
+      req.user.id,
+      recipient.id,
+      filePath,
+      sodium.to_base64(nonce),
+      sodium.to_base64(key),
+      'sent',
+      JSON.stringify(metadata),
+    ],
+  );
+  notifyMessage(recipient.id, { from: req.user.username, messageId: result.lastID });
+  await recordTrail(req.user.id, 'media');
+  await recordTrail(recipient.id, 'media');
+  res.json({ success: true, id: result.lastID });
+});
+
+app.get('/api/messages/:username', authMiddleware, async (req, res) => {
+  const peer = await get('SELECT id, public_key FROM users WHERE username = ?', [req.params.username.toLowerCase()]);
+  if (!peer) return res.status(404).json({ error: 'User not found' });
+  const rows = await all(
+    `SELECT messages.*, sender.username AS sender_username, sender.public_key AS sender_public_key
+     FROM messages
+     JOIN users AS sender ON sender.id = messages.sender_id
+     WHERE (sender_id = ? AND recipient_id = ?) OR (sender_id = ? AND recipient_id = ?)
+     ORDER BY messages.created_at ASC`,
+    [req.user.id, peer.id, peer.id, req.user.id],
+  );
+  const messages = [];
+  for (const row of rows) {
+    const metadata = parseMetadata(row.metadata);
+    const ephemeral = metadata?.ephemeral?.enabled;
+    let expired = false;
+    if (ephemeral) {
+      const limit = metadata.ephemeral.viewLimit || 1;
+      const viewCount = await get('SELECT COUNT(*) AS total FROM ephemeral_views WHERE message_id = ? AND viewer_id = ?', [row.id, req.user.id]);
+      const alreadyViewed = viewCount?.total > 0;
+      if (!alreadyViewed) {
+        await run('INSERT INTO ephemeral_views (message_id, viewer_id) VALUES (?, ?)', [row.id, req.user.id]);
+      }
+      const latestCount = alreadyViewed ? viewCount.total : (viewCount?.total || 0) + 1;
+      const createdAt = new Date(row.created_at).getTime();
+      const expiresSeconds = metadata.ephemeral.expiresSeconds || null;
+      const now = Date.now();
+      if ((expiresSeconds && now - createdAt > expiresSeconds * 1000) || latestCount >= limit) {
+        expired = true;
+        await run('DELETE FROM messages WHERE id = ?', [row.id]);
+        await run('DELETE FROM ephemeral_views WHERE message_id = ?', [row.id]);
+        continue;
+      }
+    }
+    messages.push({
+      id: row.id,
+      direction: row.sender_id === req.user.id ? 'sent' : 'received',
+      ciphertext: row.ciphertext,
+      nonce: row.nonce,
+      senderPublicKey: row.sender_public_key,
+      attachmentId: row.attachment_path ? row.id : null,
+      createdAt: row.created_at,
+      status: row.status,
+      metadata,
+      expired,
+    });
+  }
+  res.json({ messages });
+});
+
+app.get('/api/messages/attachment/:id', authMiddleware, async (req, res) => {
+  const message = await get('SELECT * FROM messages WHERE id = ?', [req.params.id]);
+  if (!message) return res.status(404).json({ error: 'Not found' });
+  if (![message.sender_id, message.recipient_id].includes(req.user.id)) {
+    return res.status(403).json({ error: 'Forbidden' });
+  }
+  if (!message.attachment_path) return res.status(404).json({ error: 'No attachment' });
+  const metadata = parseMetadata(message.metadata);
+  if (metadata?.secretFilter?.requiresInteraction) {
+    const unlocked = await get('SELECT 1 FROM message_unlocks WHERE message_id = ? AND user_id = ?', [message.id, req.user.id]);
+    if (!unlocked) {
+      return res.status(423).json({ error: 'Locked by secret filter', filter: metadata.secretFilter });
+    }
+  }
+  if (metadata?.ephemeral?.enabled) {
+    const limit = metadata.ephemeral.viewLimit || 1;
+    const viewCount = await get('SELECT COUNT(*) AS total FROM ephemeral_views WHERE message_id = ? AND viewer_id = ?', [message.id, req.user.id]);
+    const alreadyViewed = viewCount?.total > 0;
+    if (!alreadyViewed) {
+      await run('INSERT INTO ephemeral_views (message_id, viewer_id) VALUES (?, ?)', [message.id, req.user.id]);
+    }
+    const totalViews = alreadyViewed ? viewCount.total : (viewCount?.total || 0) + 1;
+    if (totalViews > limit) {
+      await run('DELETE FROM messages WHERE id = ?', [message.id]);
+      await run('DELETE FROM ephemeral_views WHERE message_id = ?', [message.id]);
+      if (fs.existsSync(message.attachment_path)) {
+        fs.rmSync(message.attachment_path, { force: true });
+      }
+      return res.status(410).json({ error: 'Ephemeral attachment expired' });
+    }
+  }
+  const ciphertext = fs.readFileSync(message.attachment_path);
+  const nonce = sodium.from_base64(message.attachment_nonce);
+  const key = sodium.from_base64(message.attachment_key);
+  const plaintext = sodium.crypto_aead_xchacha20poly1305_ietf_decrypt(null, ciphertext, null, nonce, key);
+  res.setHeader('Content-Type', 'application/octet-stream');
+  res.send(Buffer.from(plaintext));
+});
+
+app.post('/api/messages/:id/unlock', authMiddleware, async (req, res) => {
+  const message = await get('SELECT id, metadata, sender_id, recipient_id FROM messages WHERE id = ?', [req.params.id]);
+  if (!message) return res.status(404).json({ error: 'Message not found' });
+  if (![message.sender_id, message.recipient_id].includes(req.user.id)) {
+    return res.status(403).json({ error: 'Forbidden' });
+  }
+  const metadata = parseMetadata(message.metadata);
+  if (!metadata?.secretFilter?.requiresInteraction) {
+    return res.json({ unlocked: true, filter: null });
+  }
+  const { action } = req.body || {};
+  const requiredAction = metadata.secretFilter?.type === 'orbit' ? 'rotate' : 'tap';
+  if (!action || (requiredAction === 'rotate' && action !== 'rotate') || (requiredAction === 'tap' && !['tap', 'touch'].includes(action))) {
+    return res.status(400).json({ error: `Perform a ${requiredAction} gesture to unlock` });
+  }
+  await run('INSERT OR REPLACE INTO message_unlocks (message_id, user_id) VALUES (?, ?)', [message.id, req.user.id]);
+  res.json({ unlocked: true, filter: metadata.secretFilter?.type || null });
+});
+
+app.get('/api/albums', authMiddleware, async (req, res) => {
+  const albums = await all(
+    `SELECT albums.id, albums.name, albums.theme, albums.owner_id, owners.username AS owner_username
+     FROM albums
+     JOIN users AS owners ON owners.id = albums.owner_id
+     WHERE albums.owner_id = ? OR albums.id IN (SELECT album_id FROM album_members WHERE user_id = ?)
+     ORDER BY albums.created_at DESC`,
+    [req.user.id, req.user.id],
+  );
+  const albumIds = albums.map((album) => album.id);
+  const members = albumIds.length
+    ? await all(
+        `SELECT album_members.album_id, users.username, users.display_name, album_members.role
+         FROM album_members
+         JOIN users ON users.id = album_members.user_id
+         WHERE album_members.album_id IN (${albumIds.map(() => '?').join(',')})`,
+        albumIds,
+      )
+    : [];
+  const groupedMembers = members.reduce((acc, entry) => {
+    if (!acc[entry.album_id]) acc[entry.album_id] = [];
+    acc[entry.album_id].push({ username: entry.username, displayName: entry.display_name, role: entry.role });
+    return acc;
+  }, {});
+  res.json({
+    albums: albums.map((album) => ({
+      id: album.id,
+      name: album.name,
+      theme: album.theme,
+      owner: album.owner_username,
+      members: groupedMembers[album.id] || [],
+    })),
+  });
+});
+
+app.post('/api/albums', authMiddleware, async (req, res) => {
+  const { name, theme, members = [] } = req.body || {};
+  if (!name) return res.status(400).json({ error: 'Name required' });
+  const result = await run('INSERT INTO albums (owner_id, name, theme) VALUES (?, ?, ?)', [req.user.id, name, theme || 'default']);
+  await run('INSERT OR REPLACE INTO album_members (album_id, user_id, role) VALUES (?, ?, ?)', [result.lastID, req.user.id, 'owner']);
+  for (const username of members) {
+    const user = await get('SELECT id FROM users WHERE username = ?', [username.toLowerCase()]);
+    if (user) {
+      await run('INSERT OR IGNORE INTO album_members (album_id, user_id, role) VALUES (?, ?, ?)', [result.lastID, user.id, 'viewer']);
+    }
+  }
+  await recordTrail(req.user.id, 'album-create');
+  res.json({ success: true, id: result.lastID });
+});
+
+app.post('/api/albums/:id/invite', authMiddleware, async (req, res) => {
+  const album = await get('SELECT * FROM albums WHERE id = ?', [req.params.id]);
+  if (!album) return res.status(404).json({ error: 'Album not found' });
+  if (album.owner_id !== req.user.id) return res.status(403).json({ error: 'Only owners can invite' });
+  const { username } = req.body || {};
+  if (!username) return res.status(400).json({ error: 'Username required' });
+  const user = await get('SELECT id FROM users WHERE username = ?', [username.toLowerCase()]);
+  if (!user) return res.status(404).json({ error: 'User not found' });
+  await run('INSERT OR IGNORE INTO album_members (album_id, user_id, role) VALUES (?, ?, ?)', [album.id, user.id, 'viewer']);
+  res.json({ success: true });
+});
+
+app.post('/api/albums/:id/items', authMiddleware, upload.single('file'), async (req, res) => {
+  if (!req.file) return res.status(400).json({ error: 'Missing file' });
+  const album = await get('SELECT * FROM albums WHERE id = ?', [req.params.id]);
+  if (!album) return res.status(404).json({ error: 'Album not found' });
+  const member = await get('SELECT role FROM album_members WHERE album_id = ? AND user_id = ?', [album.id, req.user.id]);
+  if (!member) return res.status(403).json({ error: 'Not part of album' });
+  const nonce = sodium.randombytes_buf(sodium.crypto_aead_xchacha20poly1305_ietf_NPUBBYTES);
+  const key = sodium.randombytes_buf(sodium.crypto_aead_xchacha20poly1305_ietf_KEYBYTES);
+  const ciphertext = sodium.crypto_aead_xchacha20poly1305_ietf_encrypt(req.file.buffer, null, null, nonce, key);
+  const payload = {
+    key: sodium.to_base64(key),
+    data: sodium.to_base64(ciphertext),
+  };
+  await run(
+    'INSERT INTO album_items (album_id, uploader_id, ciphertext, nonce, description) VALUES (?, ?, ?, ?, ?)',
+    [album.id, req.user.id, JSON.stringify(payload), sodium.to_base64(nonce), req.body.description || ''],
+  );
+  await recordTrail(req.user.id, 'album-upload');
+  res.json({ success: true });
+});
+
+app.get('/api/albums/:id', authMiddleware, async (req, res) => {
+  const album = await get(
+    `SELECT albums.*, owners.username AS owner_username
+     FROM albums
+     JOIN users AS owners ON owners.id = albums.owner_id
+     WHERE albums.id = ?`,
+    [req.params.id],
+  );
+  if (!album) return res.status(404).json({ error: 'Album not found' });
+  const member = await get('SELECT role FROM album_members WHERE album_id = ? AND user_id = ?', [album.id, req.user.id]);
+  if (!member && album.owner_id !== req.user.id) return res.status(403).json({ error: 'Not part of album' });
+  const items = await all(
+    `SELECT album_items.*, users.username AS uploader_username
+     FROM album_items
+     JOIN users ON users.id = album_items.uploader_id
+     WHERE album_items.album_id = ?
+     ORDER BY album_items.created_at DESC`,
+    [album.id],
+  );
+  res.json({
+    album: {
+      id: album.id,
+      name: album.name,
+      theme: album.theme,
+      owner: album.owner_username,
+    },
+    items: items.map((item) => ({
+      id: item.id,
+      uploader: item.uploader_username,
+      nonce: item.nonce,
+      description: item.description,
+      createdAt: item.created_at,
+      ciphertext: item.ciphertext,
+    })),
+  });
+});
+
+app.get('/api/constellations', authMiddleware, async (req, res) => {
+  const constellations = await getConstellationsSnapshot();
+  res.json({ constellations });
+});
+
+app.post('/api/constellations', authMiddleware, async (req, res) => {
+  const { name, style, links = [] } = req.body || {};
+  if (!name) return res.status(400).json({ error: 'Name required' });
+  const result = await run('INSERT INTO constellations (owner_id, name, style) VALUES (?, ?, ?)', [req.user.id, name, style || 'default']);
+  for (const entry of links) {
+    if (!entry?.from || !entry?.to) continue;
+    const fromUser = await get('SELECT id FROM users WHERE username = ?', [entry.from.toLowerCase()]);
+    const toUser = await get('SELECT id FROM users WHERE username = ?', [entry.to.toLowerCase()]);
+    if (fromUser && toUser) {
+      await run('INSERT OR IGNORE INTO constellation_links (constellation_id, from_user, to_user) VALUES (?, ?, ?)', [result.lastID, fromUser.id, toUser.id]);
+    }
+  }
+  await recordTrail(req.user.id, 'constellation-create');
+  broadcastPresence();
+  res.json({ success: true, id: result.lastID });
+});
+
+app.post('/api/constellations/:id/links', authMiddleware, async (req, res) => {
+  const constellation = await get('SELECT * FROM constellations WHERE id = ?', [req.params.id]);
+  if (!constellation) return res.status(404).json({ error: 'Constellation not found' });
+  if (constellation.owner_id !== req.user.id) return res.status(403).json({ error: 'Only owners can modify links' });
+  const { from, to } = req.body || {};
+  if (!from || !to) return res.status(400).json({ error: 'from/to required' });
+  const fromUser = await get('SELECT id FROM users WHERE username = ?', [from.toLowerCase()]);
+  const toUser = await get('SELECT id FROM users WHERE username = ?', [to.toLowerCase()]);
+  if (!fromUser || !toUser) return res.status(404).json({ error: 'Users not found' });
+  await run('INSERT OR IGNORE INTO constellation_links (constellation_id, from_user, to_user) VALUES (?, ?, ?)', [constellation.id, fromUser.id, toUser.id]);
+  broadcastPresence();
+  res.json({ success: true });
+});
+
+app.delete('/api/constellations/:id/links', authMiddleware, async (req, res) => {
+  const constellation = await get('SELECT * FROM constellations WHERE id = ?', [req.params.id]);
+  if (!constellation) return res.status(404).json({ error: 'Constellation not found' });
+  if (constellation.owner_id !== req.user.id) return res.status(403).json({ error: 'Only owners can modify links' });
+  const { from, to } = req.body || {};
+  if (!from || !to) return res.status(400).json({ error: 'from/to required' });
+  const fromUser = await get('SELECT id FROM users WHERE username = ?', [from.toLowerCase()]);
+  const toUser = await get('SELECT id FROM users WHERE username = ?', [to.toLowerCase()]);
+  if (!fromUser || !toUser) return res.status(404).json({ error: 'Users not found' });
+  await run('DELETE FROM constellation_links WHERE constellation_id = ? AND from_user = ? AND to_user = ?', [constellation.id, fromUser.id, toUser.id]);
+  broadcastPresence();
+  res.json({ success: true });
+});
+
+app.get('/api/secret-links', authMiddleware, async (req, res) => {
+  const links = await all('SELECT * FROM secret_links WHERE owner_id = ? ORDER BY created_at DESC', [req.user.id]);
+  res.json({
+    links: links.map((link) => ({
+      id: link.id,
+      label: link.label,
+      cipher: link.cipher,
+      nonce: link.nonce,
+      sealedKeys: (() => {
+        if (!link.sealed_keys) return null;
+        try {
+          return JSON.parse(link.sealed_keys);
+        } catch (error) {
+          console.warn('Unable to parse sealed_keys payload for secret link', link.id, error);
+          return null;
+        }
+      })(),
+      audience: link.audience ? JSON.parse(link.audience) : [],
+      expiresAt: link.expires_at,
+      createdAt: link.created_at,
+    })),
+  });
+});
+
+app.post('/api/secret-links', authMiddleware, async (req, res) => {
+  const { label, cipher, nonce, audience = [], expiresAt } = req.body || {};
+  let sealedKeys = null;
+  let resolvedCipher = cipher;
+  if (cipher && typeof cipher === 'object') {
+    if (!cipher.ciphertext || !cipher.sealedKeys) {
+      return res.status(400).json({ error: 'cipher payload malformed' });
+    }
+    resolvedCipher = cipher.ciphertext;
+    sealedKeys = cipher.sealedKeys;
+  }
+  if (!label || !resolvedCipher || !nonce) {
+    return res.status(400).json({ error: 'label, cipher and nonce are required' });
+  }
+  const result = await run(
+    'INSERT INTO secret_links (owner_id, label, cipher, nonce, sealed_keys, audience, expires_at) VALUES (?, ?, ?, ?, ?, ?, ?)',
+    [
+      req.user.id,
+      label,
+      resolvedCipher,
+      nonce,
+      sealedKeys ? JSON.stringify(sealedKeys) : null,
+      JSON.stringify(audience),
+      expiresAt || null,
+    ],
+  );
+  await recordTrail(req.user.id, 'secret-link');
+  broadcastPresence();
+  res.json({ success: true, id: result.lastID });
+});
+
+app.delete('/api/secret-links/:id', authMiddleware, async (req, res) => {
+  await run('DELETE FROM secret_links WHERE id = ? AND owner_id = ?', [req.params.id, req.user.id]);
+  broadcastPresence();
+  res.json({ success: true });
+});
+
+function initialGameState(type, creatorUsername, opponentUsername) {
+  if (type === 'tic-tac-toe') {
+    return {
+      type,
+      board: Array(9).fill(null),
+      turn: 'X',
+      players: { X: creatorUsername, O: opponentUsername },
+      moves: [],
+      winner: null,
+    };
+  }
+  if (type === 'trivia') {
+    return {
+      type,
+      prompt: 'First to answer wins. Answer with /buzz',
+      buzzed: null,
+      history: [],
+    };
+  }
+  return { type, state: {}, createdAt: new Date().toISOString() };
+}
+
+function determineWinner(board) {
+  const lines = [
+    [0, 1, 2],
+    [3, 4, 5],
+    [6, 7, 8],
+    [0, 3, 6],
+    [1, 4, 7],
+    [2, 5, 8],
+    [0, 4, 8],
+    [2, 4, 6],
+  ];
+  for (const [a, b, c] of lines) {
+    if (board[a] && board[a] === board[b] && board[a] === board[c]) {
+      return board[a];
+    }
+  }
+  return board.every((cell) => cell) ? 'draw' : null;
+}
+
+app.get('/api/games', authMiddleware, async (req, res) => {
+  const games = await all(
+    `SELECT chat_games.*, creator.username AS creator_username, opponent.username AS opponent_username
+     FROM chat_games
+     JOIN users AS creator ON creator.id = chat_games.creator_id
+     JOIN users AS opponent ON opponent.id = chat_games.opponent_id
+     WHERE creator_id = ? OR opponent_id = ?
+     ORDER BY chat_games.updated_at DESC`,
+    [req.user.id, req.user.id],
+  );
+  res.json({
+    games: games.map((game) => ({
+      id: game.id,
+      type: game.type,
+      status: game.status,
+      state: parseMetadata(game.state),
+      creator: game.creator_username,
+      opponent: game.opponent_username,
+      updatedAt: game.updated_at,
+    })),
+  });
+});
+
+app.post('/api/games', authMiddleware, async (req, res) => {
+  const { opponent, type = 'tic-tac-toe' } = req.body || {};
+  if (!opponent) return res.status(400).json({ error: 'opponent required' });
+  const opponentUser = await get('SELECT id, username FROM users WHERE username = ?', [opponent.toLowerCase()]);
+  if (!opponentUser) return res.status(404).json({ error: 'Opponent not found' });
+  const initialState = initialGameState(type, req.user.username, opponentUser.username);
+  const result = await run(
+    'INSERT INTO chat_games (type, creator_id, opponent_id, state) VALUES (?, ?, ?, ?)',
+    [type, req.user.id, opponentUser.id, JSON.stringify(initialState)],
+  );
+  await recordTrail(req.user.id, 'game-start');
+  notifyGame(opponentUser.id, { id: result.lastID, type, state: initialState });
+  res.json({ success: true, id: result.lastID, state: initialState });
+});
+
+app.get('/api/games/:id', authMiddleware, async (req, res) => {
+  const game = await get(
+    `SELECT chat_games.*, creator.username AS creator_username, opponent.username AS opponent_username
+     FROM chat_games
+     JOIN users AS creator ON creator.id = chat_games.creator_id
+     JOIN users AS opponent ON opponent.id = chat_games.opponent_id
+     WHERE chat_games.id = ?`,
+    [req.params.id],
+  );
+  if (!game) return res.status(404).json({ error: 'Game not found' });
+  if (![game.creator_id, game.opponent_id].includes(req.user.id)) return res.status(403).json({ error: 'Forbidden' });
+  res.json({
+    id: game.id,
+    type: game.type,
+    status: game.status,
+    creator: game.creator_username,
+    opponent: game.opponent_username,
+    state: parseMetadata(game.state),
+  });
+});
+
+app.post('/api/games/:id/move', authMiddleware, async (req, res) => {
+  const game = await get('SELECT * FROM chat_games WHERE id = ?', [req.params.id]);
+  if (!game) return res.status(404).json({ error: 'Game not found' });
+  if (![game.creator_id, game.opponent_id].includes(req.user.id)) return res.status(403).json({ error: 'Forbidden' });
+  const state = parseMetadata(game.state);
+  if (game.status !== 'active') return res.status(400).json({ error: 'Game finished' });
+  const { move } = req.body || {};
+  if (state.type === 'tic-tac-toe') {
+    const symbol = state.players.X === req.user.username ? 'X' : 'O';
+    if (state.turn !== symbol) return res.status(400).json({ error: 'Not your turn' });
+    const index = Number(move);
+    if (Number.isNaN(index) || index < 0 || index > 8) return res.status(400).json({ error: 'Invalid move' });
+    if (state.board[index]) return res.status(400).json({ error: 'Spot taken' });
+    state.board[index] = symbol;
+    state.moves.push({ by: req.user.username, index });
+    const winner = determineWinner(state.board);
+    if (winner) {
+      state.winner = winner === 'draw' ? null : winner;
+      game.status = winner === 'draw' ? 'draw' : 'finished';
+    } else {
+      state.turn = symbol === 'X' ? 'O' : 'X';
+    }
+  } else if (state.type === 'trivia') {
+    if (move === '/buzz' && !state.buzzed) {
+      state.buzzed = req.user.username;
+      state.history.push({ action: 'buzz', by: req.user.username, at: new Date().toISOString() });
+    } else if (state.buzzed === req.user.username) {
+      state.history.push({ action: 'answer', by: req.user.username, text: move, at: new Date().toISOString() });
+      game.status = 'finished';
+      state.winner = req.user.username;
+    } else {
+      state.history.push({ action: 'chat', by: req.user.username, text: move, at: new Date().toISOString() });
+    }
+  }
+  await run('UPDATE chat_games SET state = ?, status = ?, updated_at = CURRENT_TIMESTAMP WHERE id = ?', [JSON.stringify(state), game.status, game.id]);
+  const opponentId = game.creator_id === req.user.id ? game.opponent_id : game.creator_id;
+  await recordTrail(req.user.id, 'game-move');
+  notifyGame(opponentId, { id: game.id, state, status: game.status });
+  res.json({ success: true, state, status: game.status });
+});
+
+app.get('/api/qr/treasure', authMiddleware, async (req, res) => {
+  const treasures = await all('SELECT * FROM qr_treasures ORDER BY created_at DESC');
+  const claims = await all('SELECT treasure_id FROM qr_claims WHERE user_id = ?', [req.user.id]);
+  const claimSet = new Set(claims.map((claim) => claim.treasure_id));
+  res.json({
+    hunts: treasures.map((treasure) => ({
+      id: treasure.id,
+      hint: treasure.hint,
+      expiresAt: treasure.expires_at,
+      creatorId: treasure.creator_id,
+      claimed: claimSet.has(treasure.id),
+      payload: treasure.creator_id === req.user.id || claimSet.has(treasure.id) ? treasure.payload : null,
+    })),
+  });
+});
+
+app.post('/api/qr/treasure', authMiddleware, async (req, res) => {
+  const { code, hint, payload, expiresAt } = req.body || {};
+  if (!code || !payload) return res.status(400).json({ error: 'code and payload required' });
+  const hashed = crypto.createHash('sha256').update(code).digest('hex');
+  const result = await run('INSERT INTO qr_treasures (creator_id, code, hint, payload, expires_at) VALUES (?, ?, ?, ?, ?)', [req.user.id, hashed, hint || '', payload, expiresAt || null]);
+  await recordTrail(req.user.id, 'treasure-create');
+  res.json({ success: true, id: result.lastID });
+});
+
+app.post('/api/qr/treasure/claim', authMiddleware, async (req, res) => {
+  const { code } = req.body || {};
+  if (!code) return res.status(400).json({ error: 'code required' });
+  const hashed = crypto.createHash('sha256').update(code).digest('hex');
+  const treasure = await get('SELECT * FROM qr_treasures WHERE code = ?', [hashed]);
+  if (!treasure) return res.status(404).json({ error: 'Treasure not found' });
+  if (treasure.expires_at && new Date(treasure.expires_at).getTime() < Date.now()) {
+    return res.status(410).json({ error: 'Treasure expired' });
+  }
+  await run('INSERT OR IGNORE INTO qr_claims (treasure_id, user_id) VALUES (?, ?)', [treasure.id, req.user.id]);
+  await recordTrail(req.user.id, 'treasure-claim');
+  res.json({ success: true, payload: treasure.payload });
+});
+
+app.get('/api/qr/me', authMiddleware, async (req, res) => {
+  const url = `enclypse:${req.user.username}`;
+  const buffer = await QRCode.toBuffer(url, { width: 320, margin: 1 });
+  res.setHeader('Content-Type', 'image/png');
+  res.send(buffer);
+});
+
+app.get('/api/qr/:username', async (req, res) => {
+  const buffer = await QRCode.toBuffer(`enclypse:${req.params.username.toLowerCase()}`, { width: 320, margin: 1 });
+  res.setHeader('Content-Type', 'image/png');
+  res.send(buffer);
+});
+
+app.use('/enclypse', express.static(path.resolve(__dirname, '../frontend')));
+
+const PORT = process.env.PORT || 4000;
+server.listen(PORT, () => {
+  console.log(`Enclypse backend listening on http://localhost:${PORT}`);
+});
+
+wss.on('connection', async (socket, req) => {
+  const url = new URL(req.url, 'http://localhost');
+  const token = url.searchParams.get('token');
+  const session = await authenticateToken(token);
+  if (!session) {
+    socket.close();
+    return;
+  }
+  const entry = onlineUsers.get(session.user_id) || { username: session.username, displayName: session.display_name, sockets: new Set() };
+  entry.sockets.add(socket);
+  onlineUsers.set(session.user_id, entry);
+  await recordTrail(session.user_id, 'online');
+  broadcastPresence();
+
+  socket.on('close', async () => {
+    const updated = onlineUsers.get(session.user_id);
+    if (!updated) return;
+    updated.sockets.delete(socket);
+    if (!updated.sockets.size) {
+      onlineUsers.delete(session.user_id);
+    }
+    await recordTrail(session.user_id, 'offline');
+    broadcastPresence();
+  });
+});
+
+function notifyMessage(userId, payload) {
+  const entry = onlineUsers.get(userId);
+  if (!entry) return;
+  entry.sockets.forEach((socket) => safeSend(socket, { type: 'message:new', payload }));
+}
+
+function notifyGame(userId, payload) {
+  const entry = onlineUsers.get(userId);
+  if (!entry) return;
+  entry.sockets.forEach((socket) => safeSend(socket, { type: 'game:update', payload }));
+}

--- a/enclypse/frontend/chat.html
+++ b/enclypse/frontend/chat.html
@@ -1,0 +1,1107 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <title>Enclypse – Chat</title>
+    <link rel="stylesheet" href="style.css" />
+  </head>
+  <body>
+    <main>
+      <nav>
+        <a href="sphere.html">Sphere</a>
+        <a href="contacts.html">Contacts</a>
+        <a href="search.html">Search</a>
+        <a href="chat.html" class="active">Chat</a>
+        <a href="profile.html">Profile</a>
+        <a href="#" id="logout-link">Logout</a>
+      </nav>
+      <section class="card chat-card">
+        <h1 id="chat-title">Chat</h1>
+        <div class="chat-columns">
+          <div class="chat-column">
+            <div class="channel-toggle">
+              <label for="transport-select">Channel</label>
+              <div class="channel-controls">
+                <select id="transport-select">
+                  <option value="internet">Internet (Wi‑Fi)</option>
+                  <option value="bluetooth">Bluetooth</option>
+                </select>
+                <span class="badge" id="transport-status">Checking…</span>
+              </div>
+            </div>
+            <div class="chat-flair">
+              <label class="toggle">
+                <input type="checkbox" id="ephemeral-toggle" />
+                <span>Ephemeral blast</span>
+              </label>
+              <div class="flair-inline" id="ephemeral-settings">
+                <label>Views <input type="number" id="ephemeral-limit" min="1" value="1" /></label>
+                <label>Expires (sec) <input type="number" id="ephemeral-seconds" min="0" step="30" value="0" /></label>
+              </div>
+              <label class="flair-select">
+                <span>Secret filter</span>
+                <select id="secret-filter">
+                  <option value="">None</option>
+                  <option value="prism">Prism glow</option>
+                  <option value="orbit">Orbit shift</option>
+                  <option value="pulse">Pulse bloom</option>
+                </select>
+              </label>
+              <label class="flair-input">
+                <span>Secret link</span>
+                <input type="text" id="secret-link-input" placeholder="Hidden portal URL or clue" />
+              </label>
+            </div>
+            <div class="chat-window">
+              <div class="chat-messages" id="messages"></div>
+              <form class="chat-input" id="message-form">
+                <input type="text" id="message" placeholder="Type an encrypted message" autocomplete="off" required />
+                <label class="file-label" for="attachment">📎 Attach</label>
+                <input type="file" id="attachment" accept="image/*" />
+                <button type="submit">Send</button>
+              </form>
+            </div>
+          </div>
+          <aside class="chat-side">
+            <section class="panel" id="sidekick-panel">
+              <header>
+                <h2>AI sidekick</h2>
+                <p>Summaries and memes stay on-device.</p>
+              </header>
+              <div class="sidekick-controls">
+                <button type="button" id="sidekick-summary">Summarize chat</button>
+                <button type="button" id="sidekick-meme" class="secondary">Spin a meme</button>
+              </div>
+              <pre id="sidekick-output">Waiting for inspiration…</pre>
+            </section>
+            <section class="panel" id="game-panel">
+              <header>
+                <h2>Mini-games</h2>
+                <p>Challenge your friend in real time.</p>
+              </header>
+              <div class="game-controls">
+                <select id="game-type">
+                  <option value="tic-tac-toe">Tic-Tac-Toe</option>
+                  <option value="trivia">Trivia Buzz</option>
+                </select>
+                <button type="button" id="start-game">Start game</button>
+              </div>
+              <p class="game-instructions" id="game-instructions">Choose a game to see the rules.</p>
+              <div class="game-board" id="game-board">
+                <button type="button" class="cell" data-index="0"></button>
+                <button type="button" class="cell" data-index="1"></button>
+                <button type="button" class="cell" data-index="2"></button>
+                <button type="button" class="cell" data-index="3"></button>
+                <button type="button" class="cell" data-index="4"></button>
+                <button type="button" class="cell" data-index="5"></button>
+                <button type="button" class="cell" data-index="6"></button>
+                <button type="button" class="cell" data-index="7"></button>
+                <button type="button" class="cell" data-index="8"></button>
+              </div>
+              <div class="game-actions">
+                <button type="button" id="game-buzz">Buzz</button>
+                <input type="text" id="game-answer" placeholder="Your move or punchline" />
+                <button type="button" id="game-submit">Send</button>
+              </div>
+              <div class="game-status" id="game-status">No active game.</div>
+            </section>
+            <section class="panel" id="album-panel">
+              <header>
+                <h2>Shared albums</h2>
+                <p>Create an encrypted gallery.</p>
+              </header>
+              <form id="album-create">
+                <input type="text" id="album-name" placeholder="Album name" required />
+                <button type="submit">Spawn album</button>
+              </form>
+              <div class="album-uploader">
+                <input type="file" id="album-file" accept="image/*" />
+                <input type="text" id="album-caption" placeholder="Caption" />
+                <button type="button" id="album-upload">Upload to latest</button>
+              </div>
+              <ul id="album-list"></ul>
+            </section>
+            <section class="panel" id="secret-links-panel">
+              <header>
+                <h2>Secret rooms</h2>
+                <p>Drop portals between nodes.</p>
+              </header>
+              <form id="secret-link-form">
+                <input type="text" id="secret-link-label" placeholder="Label" required />
+                <input type="text" id="secret-link-destination" placeholder="Encrypted payload" required />
+                <button type="submit">Store link</button>
+              </form>
+              <ul id="secret-link-list"></ul>
+            </section>
+            <section class="panel" id="treasure-panel">
+              <header>
+                <h2>QR treasure</h2>
+                <p>Hide easter eggs for your circles.</p>
+              </header>
+              <form id="treasure-form">
+                <input type="text" id="treasure-code" placeholder="Secret code" required />
+                <input type="text" id="treasure-hint" placeholder="Hint" />
+                <textarea id="treasure-payload" placeholder="Reward details" rows="2"></textarea>
+                <button type="submit">Hide treasure</button>
+              </form>
+              <div class="treasure-claim">
+                <input type="text" id="treasure-claim-code" placeholder="Scan code" />
+                <button type="button" id="treasure-claim">Claim</button>
+              </div>
+              <ul id="treasure-list"></ul>
+            </section>
+          </aside>
+        </div>
+      </section>
+    </main>
+    <div class="album-lightbox hidden" id="album-lightbox">
+      <div class="album-lightbox__backdrop" id="album-lightbox-close"></div>
+      <div class="album-lightbox__dialog" role="dialog" aria-modal="true" aria-labelledby="album-lightbox-title">
+        <button type="button" class="album-lightbox__dismiss" id="album-lightbox-dismiss" aria-label="Close album viewer">×</button>
+        <h3 id="album-lightbox-title"></h3>
+        <div class="album-lightbox__grid" id="album-lightbox-grid"></div>
+      </div>
+    </div>
+    <script type="module">
+      import {
+        fetchConversation,
+        sendMessage,
+        sendAttachment,
+        downloadAttachment,
+        encryptMessage,
+        decryptMessage,
+        connectPresenceSocket,
+        logout,
+        api,
+        ensureReady,
+        getTransportState,
+        setTransportPreference,
+        unlockSecretFilter,
+        listGames,
+        createGame,
+        sendGameMove,
+        fetchGame,
+        listAlbums,
+        createAlbum,
+        uploadAlbumItem,
+        fetchAlbum,
+        listSecretLinks,
+        createSecretLink,
+        deleteSecretLink,
+        listTreasureHunts,
+        createTreasureHunt,
+        claimTreasure,
+        getKeyMaterial,
+        fetchUser,
+      } from './common.js';
+
+      const params = new URLSearchParams(window.location.search);
+      const partner = params.get('to');
+      const messagesList = document.getElementById('messages');
+      const form = document.getElementById('message-form');
+      const input = document.getElementById('message');
+      const fileInput = document.getElementById('attachment');
+      const transportSelect = document.getElementById('transport-select');
+      const transportStatus = document.getElementById('transport-status');
+      const ephemeralToggle = document.getElementById('ephemeral-toggle');
+      const ephemeralLimit = document.getElementById('ephemeral-limit');
+      const ephemeralSeconds = document.getElementById('ephemeral-seconds');
+      const secretFilterSelect = document.getElementById('secret-filter');
+      const secretLinkInput = document.getElementById('secret-link-input');
+      const sidekickSummary = document.getElementById('sidekick-summary');
+      const sidekickMeme = document.getElementById('sidekick-meme');
+      const sidekickOutput = document.getElementById('sidekick-output');
+      const gameTypeSelect = document.getElementById('game-type');
+      const startGameButton = document.getElementById('start-game');
+      const gameStatus = document.getElementById('game-status');
+      const gameInstructions = document.getElementById('game-instructions');
+      const gameBoardElement = document.getElementById('game-board');
+      const gameBoardCells = Array.from(document.querySelectorAll('#game-board .cell'));
+      const gameBuzzButton = document.getElementById('game-buzz');
+      const gameAnswerInput = document.getElementById('game-answer');
+      const gameSubmitButton = document.getElementById('game-submit');
+      const albumForm = document.getElementById('album-create');
+      const albumNameInput = document.getElementById('album-name');
+      const albumFileInput = document.getElementById('album-file');
+      const albumCaptionInput = document.getElementById('album-caption');
+      const albumUploadButton = document.getElementById('album-upload');
+      const albumList = document.getElementById('album-list');
+      const albumLightbox = document.getElementById('album-lightbox');
+      const albumLightboxClose = document.getElementById('album-lightbox-close');
+      const albumLightboxDismiss = document.getElementById('album-lightbox-dismiss');
+      const albumLightboxGrid = document.getElementById('album-lightbox-grid');
+      const albumLightboxTitle = document.getElementById('album-lightbox-title');
+      const secretLinkForm = document.getElementById('secret-link-form');
+      const secretLinkLabel = document.getElementById('secret-link-label');
+      const secretLinkDestination = document.getElementById('secret-link-destination');
+      const secretLinkList = document.getElementById('secret-link-list');
+      const treasureForm = document.getElementById('treasure-form');
+      const treasureCode = document.getElementById('treasure-code');
+      const treasureHint = document.getElementById('treasure-hint');
+      const treasurePayload = document.getElementById('treasure-payload');
+      const treasureClaimCode = document.getElementById('treasure-claim-code');
+      const treasureClaimButton = document.getElementById('treasure-claim');
+      const treasureList = document.getElementById('treasure-list');
+
+      const conversationCache = [];
+      let bluetoothAvailable = false;
+      let currentTransport = 'internet';
+      let partnerProfile = null;
+      let currentGameId = null;
+      let currentGameState = null;
+      let currentGameStatus = null;
+      let latestAlbumId = null;
+      let selfProfile = null;
+      const activeAlbumUrls = new Set();
+      const orbitHints = new Map();
+      let orientationListenerAttached = false;
+
+      if (partner) {
+        document.getElementById('chat-title').textContent = `Chat with ${partner}`;
+      }
+
+      applyGameLayout(gameTypeSelect.value);
+      updateGameGuidance(gameTypeSelect.value, null);
+
+      function escapeHtml(value) {
+        const div = document.createElement('div');
+        div.textContent = value;
+        return div.innerHTML;
+      }
+
+      function secretFilterInstruction(type) {
+        switch (type) {
+          case 'orbit':
+            return 'Rotate your device to align the orbit';
+          case 'prism':
+            return 'Tap and hold to refract the secret';
+          case 'pulse':
+            return 'Double-tap to sync the pulse';
+          default:
+            return 'Unlock to reveal the attachment';
+        }
+      }
+
+      function ensureOrientationTracking() {
+        if (orientationListenerAttached || !('DeviceOrientationEvent' in window)) return;
+        orientationListenerAttached = true;
+        window.addEventListener('deviceorientation', (event) => {
+          const energy = Math.abs(event.beta || 0) + Math.abs(event.gamma || 0);
+          if (energy < 60) {
+            orbitHints.forEach((entry) => {
+              entry.hintElement.classList.remove('secret-attachment__hint--primed');
+            });
+            return;
+          }
+          orbitHints.forEach((entry, button) => {
+            entry.hintElement.classList.add('secret-attachment__hint--primed');
+            button.dataset.primed = 'true';
+          });
+        });
+      }
+
+      function registerOrbitHint(button, hintElement) {
+        if (!button || !hintElement) return;
+        orbitHints.set(button, { hintElement });
+        ensureOrientationTracking();
+      }
+
+      function clearOrbitHint(button) {
+        if (!button) return;
+        const entry = orbitHints.get(button);
+        if (entry) {
+          entry.hintElement.classList.remove('secret-attachment__hint--primed');
+        }
+        orbitHints.delete(button);
+      }
+
+      function applyGameLayout(type) {
+        if (!gameBoardElement) return;
+        const trivia = type === 'trivia';
+        gameBoardElement.classList.toggle('game-board--hidden', trivia);
+        [gameBuzzButton, gameAnswerInput, gameSubmitButton].forEach((element) => {
+          if (!element) return;
+          element.classList.toggle('visually-hidden', !trivia);
+          element.disabled = !trivia;
+        });
+        if (!trivia && gameAnswerInput) {
+          gameAnswerInput.value = '';
+        }
+      }
+
+      function updateGameGuidance(type, status) {
+        if (!gameInstructions) return;
+        if (type === 'trivia') {
+          const prompt = status === 'active' ? 'Buzz first, then type your answer. First correct response wins.' : 'Start a round and be ready to /buzz!';
+          gameInstructions.textContent = prompt;
+          if (gameAnswerInput) gameAnswerInput.placeholder = 'Answer after buzzing…';
+        } else if (type === 'tic-tac-toe') {
+          const prompt = status === 'active' ? 'Tap a square on your turn to mark it.' : 'Start a match to drop an X or O.';
+          gameInstructions.textContent = prompt;
+          if (gameAnswerInput) gameAnswerInput.placeholder = 'Chat is for tactics, not inputs.';
+        } else {
+          gameInstructions.textContent = 'Choose a game to see the rules.';
+        }
+      }
+
+      function detectMimeType(bytes) {
+        if (!bytes || !bytes.length) return 'application/octet-stream';
+        const view = bytes.slice ? bytes.slice(0, 12) : bytes.subarray(0, 12);
+        if (view[0] === 0x89 && view[1] === 0x50 && view[2] === 0x4e && view[3] === 0x47) return 'image/png';
+        if (view[0] === 0xff && view[1] === 0xd8) return 'image/jpeg';
+        if (view[0] === 0x47 && view[1] === 0x49 && view[2] === 0x46) return 'image/gif';
+        if (view[8] === 0x57 && view[9] === 0x45 && view[10] === 0x42 && view[11] === 0x50) return 'image/webp';
+        return 'application/octet-stream';
+      }
+
+      function revokeAlbumUrls() {
+        activeAlbumUrls.forEach((url) => URL.revokeObjectURL(url));
+        activeAlbumUrls.clear();
+      }
+
+      function hideAlbumLightbox() {
+        revokeAlbumUrls();
+        albumLightboxGrid.innerHTML = '';
+        albumLightboxTitle.textContent = '';
+        albumLightbox.classList.add('hidden');
+        albumLightbox.classList.remove('open');
+      }
+
+      async function ensureSelfProfile() {
+        if (!selfProfile) {
+          selfProfile = await api('/api/me');
+        }
+        return selfProfile;
+      }
+
+      async function decryptAlbumItem(item) {
+        try {
+          const sodium = await ensureReady();
+          const payload = JSON.parse(item.ciphertext || '{}');
+          if (!payload?.data || !payload?.key) return null;
+          const cipherBytes = sodium.from_base64(payload.data);
+          const nonceBytes = sodium.from_base64(item.nonce);
+          const keyBytes = sodium.from_base64(payload.key);
+          const plainBytes = sodium.crypto_aead_xchacha20poly1305_ietf_decrypt(null, cipherBytes, null, nonceBytes, keyBytes);
+          const mime = detectMimeType(plainBytes);
+          const blob = new Blob([plainBytes], { type: mime });
+          const url = URL.createObjectURL(blob);
+          activeAlbumUrls.add(url);
+          return {
+            url,
+            mime,
+            description: item.description,
+            uploader: item.uploader,
+            createdAt: item.createdAt,
+          };
+        } catch (error) {
+          console.error('Failed to decrypt album item', error);
+          return null;
+        }
+      }
+
+      function trackConversation(direction, text, createdAt = new Date().toISOString()) {
+        if (!text) return;
+        conversationCache.push({ direction, text, createdAt });
+        if (conversationCache.length > 200) {
+          conversationCache.shift();
+        }
+      }
+
+      function summarizeConversation() {
+        if (!conversationCache.length) {
+          return 'No conversation yet. Say hi!';
+        }
+        const recent = conversationCache.slice(-8);
+        const sent = recent.filter((item) => item.direction === 'sent');
+        const received = recent.filter((item) => item.direction === 'received');
+        const vibe = received.slice(-3).map((item) => `• ${item.text.slice(0, 80)}${item.text.length > 80 ? '…' : ''}`).join('\n');
+        const tone = sent.length > received.length ? 'You have been steering the chat.' : 'Your friend is leading the vibe.';
+        return `Recent vibe check:\n${vibe || '• (no decrypted lines yet)'}\n\n${tone}`;
+      }
+
+      function generateMeme() {
+        const starters = ['When the node finally glows green:', 'Mood when Bluetooth actually connects:', 'You vs. the chat she tells you not to worry about:'];
+        const punchlines = ['insert dramatic drum solo', 'that moment when encryption hits different', 'galaxy brain energy'];
+        const sample = conversationCache.slice(-3).map((item) => `${item.direction === 'sent' ? 'You' : partner || 'Friend'}: ${item.text.slice(0, 60)}`);
+        return `${starters[Math.floor(Math.random() * starters.length)]}\n${sample.join('\n') || '(waiting for chat)'}\n→ ${punchlines[Math.floor(Math.random() * punchlines.length)]}`;
+      }
+
+      function updateSidekickBaseline() {
+        sidekickOutput.textContent = summarizeConversation();
+      }
+
+      function updateTransportBadge() {
+        if (!transportStatus) return;
+        if (!bluetoothAvailable) {
+          transportStatus.textContent = 'Bluetooth unavailable';
+          transportStatus.className = 'badge warning';
+          return;
+        }
+        if (currentTransport === 'bluetooth') {
+          transportStatus.textContent = 'Bluetooth linked';
+          transportStatus.className = 'badge success';
+        } else {
+          transportStatus.textContent = 'Using internet';
+          transportStatus.className = 'badge';
+        }
+      }
+
+      async function refreshTransport(initial = false) {
+        if (!transportSelect) return;
+        try {
+          const state = await getTransportState();
+          bluetoothAvailable = Boolean(state?.available?.bluetooth);
+          currentTransport = state?.active || 'internet';
+          if (initial || transportSelect.value !== currentTransport) {
+            transportSelect.value = currentTransport;
+          }
+          const bluetoothOption = transportSelect.querySelector('option[value="bluetooth"]');
+          if (bluetoothOption) {
+            bluetoothOption.disabled = !bluetoothAvailable;
+          }
+          updateTransportBadge();
+        } catch (error) {
+          bluetoothAvailable = false;
+          if (transportStatus) {
+            transportStatus.textContent = 'Channel status unavailable';
+            transportStatus.className = 'badge warning';
+          }
+        }
+      }
+
+      async function ensurePartnerProfile() {
+        if (!partner) return null;
+        if (!partnerProfile) {
+          partnerProfile = await api(`/api/users/${encodeURIComponent(partner)}`);
+        }
+        return partnerProfile;
+      }
+
+      function appendMessage({ id, direction, body, createdAt, status, metadata }) {
+        const element = document.createElement('div');
+        element.className = `message ${direction}`;
+        element.dataset.messageId = id;
+        if (metadata?.secretFilter?.type) element.dataset.secretFilter = metadata.secretFilter.type;
+        if (metadata?.ephemeral?.enabled) element.dataset.ephemeral = 'true';
+        element.innerHTML = `
+          <div class="bubble">${body}</div>
+          <small>${new Date(createdAt).toLocaleTimeString()} • ${status || 'sent'}</small>
+        `;
+        messagesList.appendChild(element);
+        messagesList.scrollTop = messagesList.scrollHeight;
+        if (metadata?.secretFilter?.type === 'orbit') {
+          const button = element.querySelector('button[data-attachment]');
+          const hint = element.querySelector('.secret-attachment__hint');
+          registerOrbitHint(button, hint);
+        }
+        return element;
+      }
+
+      async function loadMessages() {
+        if (!partner) return;
+        messagesList.innerHTML = '<p class="badge">Decrypting conversation…</p>';
+        conversationCache.length = 0;
+        const data = await fetchConversation(partner);
+        messagesList.innerHTML = '';
+        for (const message of data.messages) {
+          const metadata = message.metadata || {};
+          let bodyHtml = '<span class="badge">[Encrypted message]</span>';
+          let plainText = '';
+          if (message.ciphertext) {
+            try {
+              const decrypted = await decryptMessage(message.senderPublicKey, message.ciphertext, message.nonce);
+              plainText = decrypted;
+              bodyHtml = `<p>${escapeHtml(decrypted)}</p>`;
+            } catch (error) {
+              bodyHtml = '<p class="badge warning">[Unable to decrypt message]</p>';
+            }
+          } else if (message.attachmentId) {
+            const filterType = metadata.secretFilter?.type || '';
+            const instructions = secretFilterInstruction(filterType);
+            const filterAttr = filterType ? ` data-filter="${filterType}"` : '';
+            bodyHtml = `
+              <div class="secret-attachment${filterType ? ` secret-attachment--${filterType}` : ''}">
+                <button class="secondary secret-attachment__button" data-attachment="${message.id}"${filterAttr} aria-live="polite">
+                  ${filterType ? 'Unlock & download' : 'Download attachment'}
+                </button>
+                ${filterType ? `<div class="secret-attachment__hint"><span>${escapeHtml(instructions)}</span></div>` : ''}
+              </div>
+            `;
+          }
+          const flair = [];
+          if (metadata.ephemeral?.enabled) {
+            flair.push('<span class="badge glow">Ephemeral</span>');
+          }
+          if (metadata.secretFilter?.type) {
+            flair.push(`<span class="badge filter">${escapeHtml(secretFilterInstruction(metadata.secretFilter.type))}</span>`);
+          }
+          if (metadata.secretLink?.cipher && metadata.secretLink?.nonce) {
+            try {
+              const secret = await decryptMessage(message.senderPublicKey, metadata.secretLink.cipher, metadata.secretLink.nonce);
+              flair.push(`<button type="button" class="link-secret" data-secret="${encodeURIComponent(secret)}">Open ${escapeHtml(metadata.secretLink.label || 'secret room')}</button>`);
+            } catch (error) {
+              flair.push('<span class="badge warning">Secret room locked</span>');
+            }
+          }
+          if (flair.length) {
+            bodyHtml += `<div class="message-flair">${flair.join(' ')}</div>`;
+          }
+          appendMessage({
+            id: message.id,
+            direction: message.direction,
+            body: bodyHtml,
+            createdAt: message.createdAt,
+            status: message.status,
+            metadata,
+          });
+          if (plainText) {
+            trackConversation(message.direction, plainText, message.createdAt);
+          }
+        }
+        updateSidekickBaseline();
+      }
+
+      function buildEphemeralOptions() {
+        if (!ephemeralToggle.checked) return null;
+        return {
+          enabled: true,
+          viewLimit: Number(ephemeralLimit.value) || 1,
+          expiresSeconds: Number(ephemeralSeconds.value) || null,
+        };
+      }
+
+      function buildSecretFilterOptions() {
+        const type = secretFilterSelect.value;
+        if (!type) return null;
+        return { type };
+      }
+
+      form.addEventListener('submit', async (event) => {
+        event.preventDefault();
+        if (!partner) {
+          alert('Open a conversation by selecting a contact.');
+          return;
+        }
+        const text = input.value.trim();
+        const file = fileInput.files[0];
+        const channel = currentTransport;
+        if (channel === 'bluetooth' && !bluetoothAvailable) {
+          alert('Bluetooth is unavailable. Switch back to Internet to continue.');
+          return;
+        }
+        try {
+          const options = {};
+          const ephemeral = buildEphemeralOptions();
+          if (ephemeral) options.ephemeral = ephemeral;
+          const secretFilter = buildSecretFilterOptions();
+          if (secretFilter) options.secretFilter = secretFilter;
+          if (file) {
+            if (channel === 'bluetooth') {
+              alert('Attachments are only supported over the Internet channel.');
+              return;
+            }
+            await sendAttachment({ to: partner, file, options });
+            appendMessage({
+              id: Date.now(),
+              direction: 'sent',
+              body: '<span class="badge">[Encrypted attachment]</span>',
+              createdAt: new Date().toISOString(),
+              status: 'uploading',
+              metadata: options,
+            });
+            trackConversation('sent', '[attachment]');
+            fileInput.value = '';
+          }
+          if (text) {
+            const profile = await ensurePartnerProfile();
+            const { ciphertext, nonce } = await encryptMessage(profile.publicKey, text);
+            if (secretLinkInput.value.trim()) {
+              const secretLinkText = secretLinkInput.value.trim();
+              const secretPayload = await encryptMessage(profile.publicKey, secretLinkText);
+              options.secretLink = {
+                label: secretLinkText.slice(0, 32),
+                cipher: secretPayload.ciphertext,
+                nonce: secretPayload.nonce,
+              };
+              secretLinkInput.value = '';
+            }
+            await sendMessage({ to: partner, ciphertext, nonce, transport: channel, options });
+            const pendingStatus = channel === 'bluetooth' ? 'bluetooth' : 'sending';
+            appendMessage({
+              id: Date.now() + 1,
+              direction: 'sent',
+              body: `<p>${escapeHtml(text)}</p>`,
+              createdAt: new Date().toISOString(),
+              status: pendingStatus,
+              metadata: options,
+            });
+            trackConversation('sent', text);
+            input.value = '';
+          }
+        } catch (error) {
+          alert(error.message || 'Unable to send message');
+        }
+      });
+
+      messagesList.addEventListener('click', async (event) => {
+        const attachmentButton = event.target.closest('button[data-attachment]');
+        if (attachmentButton) {
+          try {
+            await downloadAttachment(attachmentButton.dataset.attachment);
+            attachmentButton.textContent = 'Downloaded';
+            attachmentButton.disabled = true;
+            clearOrbitHint(attachmentButton);
+          } catch (error) {
+            if (error.status === 423) {
+              const filter = attachmentButton.dataset.filter || attachmentButton.closest('.message')?.dataset.secretFilter;
+              const action = filter === 'orbit' ? 'rotate' : 'tap';
+              const hint = attachmentButton.closest('.secret-attachment')?.querySelector('.secret-attachment__hint');
+              if (hint) {
+                hint.classList.add('secret-attachment__hint--active');
+              }
+              try {
+                await unlockSecretFilter(attachmentButton.dataset.attachment, action);
+                await downloadAttachment(attachmentButton.dataset.attachment);
+                attachmentButton.textContent = 'Unlocked';
+                attachmentButton.disabled = true;
+                clearOrbitHint(attachmentButton);
+              } catch (unlockError) {
+                alert(unlockError.message || 'Unable to unlock attachment');
+              }
+            } else if (error.status === 410) {
+              attachmentButton.textContent = 'Attachment expired';
+              attachmentButton.disabled = true;
+              clearOrbitHint(attachmentButton);
+            } else {
+              alert(error.message || 'Unable to fetch attachment');
+            }
+          }
+          return;
+        }
+        const secretButton = event.target.closest('button.link-secret');
+        if (secretButton) {
+          const secret = decodeURIComponent(secretButton.dataset.secret || '');
+          const span = document.createElement('span');
+          span.className = 'badge';
+          span.textContent = secret || 'Secret unavailable';
+          secretButton.replaceWith(span);
+        }
+      });
+
+      if (transportSelect) {
+        transportSelect.addEventListener('change', async (event) => {
+          const desired = event.target.value;
+          try {
+            const result = await setTransportPreference(desired);
+            currentTransport = result?.active || desired;
+            await refreshTransport();
+          } catch (error) {
+            alert(error.message || 'Unable to switch channel');
+            transportSelect.value = currentTransport;
+            updateTransportBadge();
+          }
+        });
+      }
+
+      if (gameTypeSelect) {
+        gameTypeSelect.addEventListener('change', () => {
+          applyGameLayout(gameTypeSelect.value);
+          updateGameGuidance(gameTypeSelect.value, currentGameStatus);
+          if (!currentGameState || currentGameState.type !== gameTypeSelect.value) {
+            gameBoardCells.forEach((cell) => {
+              cell.textContent = '';
+              cell.disabled = true;
+            });
+            gameStatus.textContent = gameTypeSelect.value === 'trivia' ? 'Trivia ready. Tap Buzz to claim the floor.' : 'No active game.';
+          }
+        });
+      }
+
+      sidekickSummary.addEventListener('click', () => {
+        sidekickOutput.textContent = summarizeConversation();
+      });
+
+      sidekickMeme.addEventListener('click', () => {
+        sidekickOutput.textContent = generateMeme();
+      });
+
+      async function renderGame(state, status) {
+        currentGameState = state;
+        currentGameStatus = status || null;
+        const effectiveType = state?.type || gameTypeSelect.value;
+        applyGameLayout(effectiveType);
+        updateGameGuidance(effectiveType, status);
+        if (!state) {
+          gameBoardCells.forEach((cell) => {
+            cell.textContent = '';
+            cell.disabled = true;
+          });
+          gameStatus.textContent = 'No active game.';
+          return;
+        }
+        if (state.type === 'tic-tac-toe') {
+          gameBoardCells.forEach((cell) => {
+            const index = Number(cell.dataset.index);
+            cell.textContent = state.board[index] || '';
+            cell.disabled = Boolean(state.board[index]) || status !== 'active';
+          });
+          gameStatus.textContent = status === 'active' ? `Turn: ${state.turn}` : status === 'draw' ? 'Draw! Everyone wins.' : `Winner: ${state.winner || 'unknown'}`;
+        } else {
+          gameBoardCells.forEach((cell) => {
+            cell.textContent = '';
+            cell.disabled = true;
+          });
+          const history = (state.history || []).slice(-5).map((entry) => `${entry.by}: ${entry.text || entry.action}`);
+          gameStatus.textContent = history.length ? history.join(' • ') : state.prompt || 'Trivia in progress';
+        }
+      }
+
+      async function refreshGames() {
+        if (!partner) return;
+        const { games } = await listGames();
+        const active = games.find((game) => game.creator === partner || game.opponent === partner);
+        if (active) {
+          currentGameId = active.id;
+          renderGame(active.state, active.status);
+        } else {
+          currentGameId = null;
+          renderGame(null, null);
+        }
+      }
+
+      startGameButton.addEventListener('click', async () => {
+        if (!partner) {
+          alert('Pick a friend first.');
+          return;
+        }
+        try {
+          await createGame({ opponent: partner, type: gameTypeSelect.value });
+          await refreshGames();
+        } catch (error) {
+          alert(error.message || 'Unable to start game');
+        }
+      });
+
+      gameBoardCells.forEach((cell) => {
+        cell.addEventListener('click', async () => {
+          if (!currentGameId || !currentGameState || currentGameState.type !== 'tic-tac-toe') return;
+          try {
+            await sendGameMove(currentGameId, { move: cell.dataset.index });
+          } catch (error) {
+            alert(error.message || 'Move failed');
+          }
+        });
+      });
+
+      gameBuzzButton.addEventListener('click', async () => {
+        if (!currentGameId) return;
+        try {
+          await sendGameMove(currentGameId, { move: '/buzz' });
+        } catch (error) {
+          alert(error.message || 'Buzz failed');
+        }
+      });
+
+      gameSubmitButton.addEventListener('click', async () => {
+        if (!currentGameId) return;
+        const text = gameAnswerInput.value.trim();
+        if (!text) return;
+        try {
+          await sendGameMove(currentGameId, { move: text });
+          gameAnswerInput.value = '';
+        } catch (error) {
+          alert(error.message || 'Unable to send move');
+        }
+      });
+
+      async function refreshAlbums() {
+        const { albums } = await listAlbums();
+        const scoped = partner ? albums.filter((album) => album.owner === partner || album.members.some((m) => m.username === partner)) : albums;
+        albumList.innerHTML = '';
+        if (!scoped.length) {
+          albumList.innerHTML = '<li class="empty">No shared albums yet.</li>';
+          latestAlbumId = null;
+          return;
+        }
+        latestAlbumId = scoped[0].id;
+        for (const album of scoped) {
+          const item = document.createElement('li');
+          item.dataset.album = album.id;
+          const members = album.members.map((member) => member.displayName || member.username).join(', ');
+          item.innerHTML = `
+            <strong>${escapeHtml(album.name)}</strong>
+            <span>${escapeHtml(members || 'Just you two')}</span>
+            <small>Click to explore</small>
+          `;
+          albumList.appendChild(item);
+        }
+      }
+
+      async function openAlbum(albumId) {
+        if (!albumId) return;
+        try {
+          revokeAlbumUrls();
+          const { album, items } = await fetchAlbum(albumId);
+          albumLightboxTitle.textContent = album.name;
+          albumLightboxGrid.innerHTML = '';
+          if (!items.length) {
+            albumLightboxGrid.innerHTML = '<p class="empty">No media yet.</p>';
+          } else {
+            for (const item of items) {
+              const decrypted = await decryptAlbumItem(item);
+              const figure = document.createElement('figure');
+              figure.className = 'album-lightbox__item';
+              if (decrypted && decrypted.mime.startsWith('image/')) {
+                const img = document.createElement('img');
+                img.src = decrypted.url;
+                img.alt = `Encrypted upload by ${item.uploader}`;
+                figure.appendChild(img);
+              } else if (decrypted) {
+                const link = document.createElement('a');
+                link.href = decrypted.url;
+                link.download = `enclypse-album-${item.id}`;
+                link.className = 'album-lightbox__download';
+                link.textContent = 'Download item';
+                figure.appendChild(link);
+              } else {
+                const placeholder = document.createElement('div');
+                placeholder.className = 'album-lightbox__error';
+                placeholder.textContent = 'Unable to decrypt item.';
+                figure.appendChild(placeholder);
+              }
+              const caption = document.createElement('figcaption');
+              caption.innerHTML = `
+                <strong>${escapeHtml(item.uploader)}</strong>
+                <span>${escapeHtml(item.description || 'No caption')}</span>
+                <time datetime="${item.createdAt}">${new Date(item.createdAt).toLocaleString()}</time>
+              `;
+              figure.appendChild(caption);
+              albumLightboxGrid.appendChild(figure);
+            }
+          }
+          albumLightbox.classList.remove('hidden');
+          albumLightbox.classList.add('open');
+        } catch (error) {
+          console.error(error);
+          alert('Unable to open album');
+        }
+      }
+
+      albumForm.addEventListener('submit', async (event) => {
+        event.preventDefault();
+        if (!albumNameInput.value.trim()) return;
+        try {
+          await createAlbum({ name: albumNameInput.value.trim(), theme: secretFilterSelect.value || 'default', members: partner ? [partner] : [] });
+          albumNameInput.value = '';
+          await refreshAlbums();
+        } catch (error) {
+          alert(error.message || 'Unable to create album');
+        }
+      });
+
+      albumUploadButton.addEventListener('click', async () => {
+        if (!latestAlbumId) {
+          alert('Create an album first.');
+          return;
+        }
+        const file = albumFileInput.files[0];
+        if (!file) {
+          alert('Choose a file to upload.');
+          return;
+        }
+        try {
+          await uploadAlbumItem(latestAlbumId, { file, description: albumCaptionInput.value });
+          albumFileInput.value = '';
+          albumCaptionInput.value = '';
+          alert('Encrypted media uploaded to the album!');
+        } catch (error) {
+          alert(error.message || 'Upload failed');
+        }
+      });
+
+      albumList.addEventListener('click', async (event) => {
+        const target = event.target.closest('li[data-album]');
+        if (!target) return;
+        await openAlbum(target.dataset.album);
+      });
+
+      [albumLightboxClose, albumLightboxDismiss].forEach((element) => {
+        if (!element) return;
+        element.addEventListener('click', hideAlbumLightbox);
+      });
+
+      document.addEventListener('keydown', (event) => {
+        if (event.key === 'Escape' && albumLightbox.classList.contains('open')) {
+          hideAlbumLightbox();
+        }
+      });
+
+      window.addEventListener('beforeunload', revokeAlbumUrls);
+
+      async function refreshSecretLinks() {
+        const { links } = await listSecretLinks();
+        secretLinkList.innerHTML = '';
+        if (!links.length) {
+          secretLinkList.innerHTML = '<li class="empty">No portals yet.</li>';
+          return;
+        }
+        for (const link of links) {
+          const li = document.createElement('li');
+          const audience = (link.audience || []).join(', ');
+          const sealedCount = link.sealedKeys ? Object.keys(link.sealedKeys).length : 0;
+          li.innerHTML = `
+            <div>
+              <strong>${escapeHtml(link.label)}</strong>
+              <span>${escapeHtml(audience || 'Private stash')}</span>
+              <small>${sealedCount ? `${sealedCount} sealed key${sealedCount > 1 ? 's' : ''}` : 'Unsealed legacy link'}</small>
+            </div>
+            <button type="button" data-delete="${link.id}">Delete</button>
+          `;
+          secretLinkList.appendChild(li);
+        }
+      }
+
+      async function buildSecretLinkCipher(destination, audience = []) {
+        const sodium = await ensureReady();
+        const payloadBytes = sodium.from_string(destination);
+        const secretKey = sodium.randombytes_buf(sodium.crypto_secretbox_KEYBYTES);
+        const nonceBytes = sodium.randombytes_buf(sodium.crypto_secretbox_NONCEBYTES);
+        const ciphertextBytes = sodium.crypto_secretbox_easy(payloadBytes, nonceBytes, secretKey);
+        const sealedKeys = {};
+        const participants = new Set((audience || []).map((user) => user.toLowerCase()));
+        const self = await ensureSelfProfile();
+        const keyMaterial = getKeyMaterial();
+        if (!keyMaterial.publicKey) {
+          throw new Error('Missing local public key; re-login to regenerate keys.');
+        }
+        const selfPublic = sodium.from_base64(keyMaterial.publicKey);
+        sealedKeys[self.username] = sodium.to_base64(sodium.crypto_box_seal(secretKey, selfPublic));
+        for (const username of participants) {
+          if (!username || username === self.username) continue;
+          const profile = await fetchUser(username);
+          if (!profile?.publicKey) {
+            throw new Error(`Missing encryption key for ${username}`);
+          }
+          const recipientKey = sodium.from_base64(profile.publicKey);
+          sealedKeys[profile.username] = sodium.to_base64(sodium.crypto_box_seal(secretKey, recipientKey));
+        }
+        return {
+          cipher: {
+            ciphertext: sodium.to_base64(ciphertextBytes),
+            sealedKeys,
+          },
+          nonce: sodium.to_base64(nonceBytes),
+        };
+      }
+
+      secretLinkForm.addEventListener('submit', async (event) => {
+        event.preventDefault();
+        if (!secretLinkLabel.value.trim() || !secretLinkDestination.value.trim()) return;
+        try {
+          const destination = secretLinkDestination.value.trim();
+          const scopedAudience = partner ? [partner] : [];
+          const payload = await buildSecretLinkCipher(destination, scopedAudience);
+          await createSecretLink({
+            label: secretLinkLabel.value.trim(),
+            cipher: payload.cipher,
+            nonce: payload.nonce,
+            audience: scopedAudience,
+          });
+          secretLinkLabel.value = '';
+          secretLinkDestination.value = '';
+          await refreshSecretLinks();
+        } catch (error) {
+          alert(error.message || 'Unable to store secret link');
+        }
+      });
+
+      secretLinkList.addEventListener('click', async (event) => {
+        const button = event.target.closest('button[data-delete]');
+        if (!button) return;
+        try {
+          await deleteSecretLink(button.dataset.delete);
+          await refreshSecretLinks();
+        } catch (error) {
+          alert(error.message || 'Unable to remove link');
+        }
+      });
+
+      async function refreshTreasure() {
+        const { hunts } = await listTreasureHunts();
+        treasureList.innerHTML = '';
+        if (!hunts.length) {
+          treasureList.innerHTML = '<li class="empty">No hunts yet.</li>';
+          return;
+        }
+        for (const hunt of hunts) {
+          const li = document.createElement('li');
+          li.innerHTML = `
+            <strong>${escapeHtml(hunt.hint || 'Mystery drop')}</strong>
+            <span>${hunt.claimed ? 'Claimed' : 'Unclaimed'}</span>
+            ${hunt.payload ? `<p>${escapeHtml(hunt.payload)}</p>` : ''}
+          `;
+          treasureList.appendChild(li);
+        }
+      }
+
+      treasureForm.addEventListener('submit', async (event) => {
+        event.preventDefault();
+        if (!treasureCode.value.trim() || !treasurePayload.value.trim()) return;
+        try {
+          await createTreasureHunt({ code: treasureCode.value.trim(), hint: treasureHint.value.trim(), payload: treasurePayload.value.trim() });
+          treasureCode.value = '';
+          treasureHint.value = '';
+          treasurePayload.value = '';
+          await refreshTreasure();
+        } catch (error) {
+          alert(error.message || 'Unable to hide treasure');
+        }
+      });
+
+      treasureClaimButton.addEventListener('click', async () => {
+        if (!treasureClaimCode.value.trim()) return;
+        try {
+          const result = await claimTreasure(treasureClaimCode.value.trim());
+          alert(`Reward unlocked: ${result.payload}`);
+          treasureClaimCode.value = '';
+          await refreshTreasure();
+        } catch (error) {
+          alert(error.message || 'Unable to claim treasure');
+        }
+      });
+
+      connectPresenceSocket(async (payload) => {
+        if (!partner) return;
+        const message = payload.message;
+        if (message && message.from === partner) {
+          await loadMessages();
+        }
+      });
+
+      window.addEventListener('enclypse:game', async (event) => {
+        if (!currentGameId) {
+          await refreshGames();
+          return;
+        }
+        const { id } = event.detail || {};
+        if (id === currentGameId) {
+          try {
+            const game = await fetchGame(id);
+            renderGame(game.state, game.status);
+          } catch (error) {
+            console.warn('Failed to update game', error);
+          }
+        }
+      });
+
+      document.getElementById('logout-link').addEventListener('click', (event) => {
+        event.preventDefault();
+        logout();
+      });
+
+      await refreshTransport(true);
+      await Promise.all([loadMessages(), refreshGames(), refreshAlbums(), refreshSecretLinks(), refreshTreasure()]);
+    </script>
+  </body>
+</html>

--- a/enclypse/frontend/common.js
+++ b/enclypse/frontend/common.js
@@ -1,0 +1,400 @@
+import sodium from 'https://cdn.jsdelivr.net/npm/libsodium-wrappers-sumo@0.7.13/+esm';
+
+let ready = false;
+let sodiumLib;
+
+const origin = window.location.origin && window.location.origin !== 'null' ? window.location.origin : '';
+const apiBase = origin.startsWith('http') ? origin.replace(/:\d+$/, ':4000') : 'http://localhost:4000';
+
+async function ensureReady() {
+  if (!ready) {
+    sodiumLib = await sodium;
+    ready = true;
+  }
+  return sodiumLib;
+}
+
+function getToken() {
+  return localStorage.getItem('enclypse.token');
+}
+
+function setToken(token) {
+  if (token) {
+    localStorage.setItem('enclypse.token', token);
+  } else {
+    localStorage.removeItem('enclypse.token');
+  }
+}
+
+function setKeyMaterial({ publicKey, privateKey }) {
+  if (publicKey) localStorage.setItem('enclypse.publicKey', publicKey);
+  if (privateKey) localStorage.setItem('enclypse.privateKey', privateKey);
+}
+
+function getKeyMaterial() {
+  return {
+    publicKey: localStorage.getItem('enclypse.publicKey'),
+    privateKey: localStorage.getItem('enclypse.privateKey'),
+  };
+}
+
+async function api(path, options = {}) {
+  const token = getToken();
+  const headers = options.headers ? { ...options.headers } : {};
+  if (token) headers.Authorization = `Bearer ${token}`;
+  if (!(options.body instanceof FormData)) {
+    headers['Content-Type'] = 'application/json';
+  }
+
+  const res = await fetch(`${apiBase}${path}`, {
+    ...options,
+    headers,
+  });
+
+  if (res.status === 401) {
+    setToken(null);
+    window.location.href = 'login.html';
+    return null;
+  }
+
+  if (!res.ok) {
+    let detail;
+    const contentType = res.headers.get('content-type');
+    if (contentType && contentType.includes('application/json')) {
+      try {
+        detail = await res.json();
+      } catch (error) {
+        detail = { error: res.statusText };
+      }
+    } else {
+      detail = await res.text();
+    }
+    const message = typeof detail === 'string' ? detail : detail?.error || res.statusText;
+    const error = new Error(message || 'Request failed');
+    error.status = res.status;
+    error.detail = detail;
+    throw error;
+  }
+
+  const contentType = res.headers.get('content-type');
+  if (contentType && contentType.includes('application/json')) {
+    return res.json();
+  }
+  return res.blob();
+}
+
+async function registerUser({ username, password, displayName }) {
+  const sodium = await ensureReady();
+  const keyPair = sodium.crypto_box_keypair();
+  const privateKeyB64 = sodium.to_base64(keyPair.privateKey);
+  const publicKeyB64 = sodium.to_base64(keyPair.publicKey);
+
+  const res = await api('/api/register', {
+    method: 'POST',
+    body: JSON.stringify({ username, password, displayName, publicKey: publicKeyB64, privateKey: privateKeyB64 }),
+  });
+
+  return res;
+}
+
+async function login({ username, password }) {
+  const result = await api('/api/login', {
+    method: 'POST',
+    body: JSON.stringify({ username, password }),
+  });
+  setToken(result.token);
+  setKeyMaterial({ publicKey: result.user.publicKey, privateKey: result.privateKey });
+  return result;
+}
+
+async function logout() {
+  await api('/api/logout', { method: 'POST' }).catch(() => {});
+  setToken(null);
+  setKeyMaterial({ publicKey: null, privateKey: null });
+  window.location.href = 'login.html';
+}
+
+async function getPresence() {
+  return api('/api/presence');
+}
+
+async function getContacts() {
+  return api('/api/contacts');
+}
+
+async function addContact(username) {
+  return api('/api/contacts', {
+    method: 'POST',
+    body: JSON.stringify({ username }),
+  });
+}
+
+async function searchUsers(query) {
+  return api(`/api/search?query=${encodeURIComponent(query)}`);
+}
+
+async function fetchConversation(username) {
+  return api(`/api/messages/${encodeURIComponent(username)}`);
+}
+
+async function fetchUser(username) {
+  return api(`/api/users/${encodeURIComponent(username)}`);
+}
+
+async function sendMessage({ to, ciphertext, nonce, transport, options }) {
+  return api('/api/messages', {
+    method: 'POST',
+    body: JSON.stringify({ to, ciphertext, nonce, transport, options }),
+  });
+}
+
+async function sendAttachment({ to, file, options }) {
+  const form = new FormData();
+  form.append('to', to);
+  form.append('file', file);
+  if (options) {
+    form.append('options', JSON.stringify(options));
+  }
+  return api('/api/messages/attachment', {
+    method: 'POST',
+    body: form,
+  });
+}
+
+async function downloadAttachment(messageId) {
+  const blob = await api(`/api/messages/attachment/${messageId}`);
+  const url = URL.createObjectURL(blob);
+  window.open(url, '_blank');
+}
+
+async function unlockSecretFilter(messageId, action) {
+  return api(`/api/messages/${messageId}/unlock`, {
+    method: 'POST',
+    body: JSON.stringify({ action }),
+  });
+}
+
+async function getPreferences() {
+  const result = await api('/api/preferences');
+  return result.preferences;
+}
+
+async function savePreferences(preferences) {
+  const result = await api('/api/preferences', {
+    method: 'POST',
+    body: JSON.stringify(preferences),
+  });
+  return result.preferences;
+}
+
+async function listAlbums() {
+  return api('/api/albums');
+}
+
+async function createAlbum(body) {
+  return api('/api/albums', {
+    method: 'POST',
+    body: JSON.stringify(body),
+  });
+}
+
+async function fetchAlbum(id) {
+  return api(`/api/albums/${id}`);
+}
+
+async function uploadAlbumItem(id, { file, description }) {
+  const form = new FormData();
+  form.append('file', file);
+  if (description) form.append('description', description);
+  return api(`/api/albums/${id}/items`, { method: 'POST', body: form });
+}
+
+async function listConstellations() {
+  return api('/api/constellations');
+}
+
+async function createConstellation(body) {
+  return api('/api/constellations', {
+    method: 'POST',
+    body: JSON.stringify(body),
+  });
+}
+
+async function addConstellationLink(id, link) {
+  return api(`/api/constellations/${id}/links`, {
+    method: 'POST',
+    body: JSON.stringify(link),
+  });
+}
+
+async function removeConstellationLink(id, link) {
+  return api(`/api/constellations/${id}/links`, {
+    method: 'DELETE',
+    body: JSON.stringify(link),
+  });
+}
+
+async function listSecretLinks() {
+  return api('/api/secret-links');
+}
+
+async function createSecretLink(body) {
+  return api('/api/secret-links', {
+    method: 'POST',
+    body: JSON.stringify(body),
+  });
+}
+
+async function deleteSecretLink(id) {
+  return api(`/api/secret-links/${id}`, { method: 'DELETE' });
+}
+
+async function listGames() {
+  return api('/api/games');
+}
+
+async function createGame(body) {
+  return api('/api/games', {
+    method: 'POST',
+    body: JSON.stringify(body),
+  });
+}
+
+async function fetchGame(id) {
+  return api(`/api/games/${id}`);
+}
+
+async function sendGameMove(id, payload) {
+  return api(`/api/games/${id}/move`, {
+    method: 'POST',
+    body: JSON.stringify(payload),
+  });
+}
+
+async function listTreasureHunts() {
+  return api('/api/qr/treasure');
+}
+
+async function createTreasureHunt(body) {
+  return api('/api/qr/treasure', {
+    method: 'POST',
+    body: JSON.stringify(body),
+  });
+}
+
+async function claimTreasure(code) {
+  return api('/api/qr/treasure/claim', {
+    method: 'POST',
+    body: JSON.stringify({ code }),
+  });
+}
+
+async function getTransportState() {
+  return api('/api/transports');
+}
+
+async function setTransportPreference(transport) {
+  return api('/api/transports', {
+    method: 'POST',
+    body: JSON.stringify({ transport }),
+  });
+}
+
+function connectPresenceSocket(onUpdate) {
+  const token = getToken();
+  if (!token) return null;
+
+  const wsUrl = `${apiBase.replace(/^http/, 'ws').replace(/:\d+$/, ':4001')}?token=${token}`;
+  const socket = new WebSocket(wsUrl);
+  socket.onmessage = (event) => {
+    const data = JSON.parse(event.data);
+    if (data.type === 'presence:update') {
+      onUpdate(data.payload);
+    }
+    if (data.type === 'message:new' && window.dispatchEvent) {
+      window.dispatchEvent(new CustomEvent('enclypse:message', { detail: data.payload }));
+    }
+    if (data.type === 'game:update' && window.dispatchEvent) {
+      window.dispatchEvent(new CustomEvent('enclypse:game', { detail: data.payload }));
+    }
+  };
+  socket.onclose = () => {
+    setTimeout(() => connectPresenceSocket(onUpdate), 4000);
+  };
+  return socket;
+}
+
+async function encryptMessage(recipientPublicKey, message) {
+  const sodium = await ensureReady();
+  const { privateKey } = getKeyMaterial();
+  if (!privateKey) throw new Error('No private key available');
+
+  const privateKeyBytes = sodium.from_base64(privateKey);
+  const publicKeyBytes = sodium.from_base64(recipientPublicKey);
+  const messageBytes = sodium.from_string(message);
+  const nonce = sodium.randombytes_buf(sodium.crypto_box_NONCEBYTES);
+  const ciphertext = sodium.crypto_box_easy(messageBytes, nonce, publicKeyBytes, privateKeyBytes);
+  return {
+    ciphertext: sodium.to_base64(ciphertext),
+    nonce: sodium.to_base64(nonce),
+  };
+}
+
+async function decryptMessage(senderPublicKey, ciphertextB64, nonceB64) {
+  const sodium = await ensureReady();
+  const { privateKey } = getKeyMaterial();
+  if (!privateKey) return null;
+  const privateKeyBytes = sodium.from_base64(privateKey);
+  const publicKeyBytes = sodium.from_base64(senderPublicKey);
+  const ciphertext = sodium.from_base64(ciphertextB64);
+  const nonce = sodium.from_base64(nonceB64);
+  const msg = sodium.crypto_box_open_easy(ciphertext, nonce, publicKeyBytes, privateKeyBytes);
+  return sodium.to_string(msg);
+}
+
+export {
+  api,
+  apiBase,
+  ensureReady,
+  getToken,
+  setToken,
+  registerUser,
+  login,
+  logout,
+  getPresence,
+  getContacts,
+  addContact,
+  searchUsers,
+  fetchConversation,
+  fetchUser,
+  sendMessage,
+  sendAttachment,
+  downloadAttachment,
+  unlockSecretFilter,
+  getPreferences,
+  savePreferences,
+  listAlbums,
+  createAlbum,
+  fetchAlbum,
+  uploadAlbumItem,
+  listConstellations,
+  createConstellation,
+  addConstellationLink,
+  removeConstellationLink,
+  listSecretLinks,
+  createSecretLink,
+  deleteSecretLink,
+  listGames,
+  createGame,
+  fetchGame,
+  sendGameMove,
+  listTreasureHunts,
+  createTreasureHunt,
+  claimTreasure,
+  connectPresenceSocket,
+  encryptMessage,
+  decryptMessage,
+  getKeyMaterial,
+  getTransportState,
+  setTransportPreference,
+};

--- a/enclypse/frontend/contacts.html
+++ b/enclypse/frontend/contacts.html
@@ -1,0 +1,112 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <title>Enclypse – Contacts</title>
+    <link rel="stylesheet" href="style.css" />
+  </head>
+  <body>
+    <main>
+      <nav>
+        <a href="sphere.html">Sphere</a>
+        <a href="contacts.html" class="active">Contacts</a>
+        <a href="search.html">Search</a>
+        <a href="chat.html">Chat</a>
+        <a href="profile.html">Profile</a>
+        <a href="#" id="logout-link">Logout</a>
+      </nav>
+      <section class="card">
+        <div class="row">
+          <div>
+            <h1>Your contacts</h1>
+            <p class="badge" id="presence-badge">Loading…</p>
+            <div class="list" id="contacts"></div>
+          </div>
+          <div>
+            <h2>Add contact</h2>
+            <form id="contact-form">
+              <input type="text" id="username" placeholder="Username" required />
+              <button type="submit">Add contact</button>
+            </form>
+            <h3>Your QR handle</h3>
+            <div class="qr-container">
+              <div id="qr-code" class="qr-code">Generating…</div>
+              <p>
+                Share this QR code to connect instantly. Scans automatically add each other as contacts.
+              </p>
+            </div>
+          </div>
+        </div>
+      </section>
+    </main>
+    <script type="module">
+      import { getContacts, addContact, logout, connectPresenceSocket, api } from './common.js';
+
+      const list = document.getElementById('contacts');
+      const form = document.getElementById('contact-form');
+      const badge = document.getElementById('presence-badge');
+      const qr = document.getElementById('qr-code');
+
+      async function loadContacts() {
+        const data = await getContacts();
+        list.innerHTML = '';
+        badge.textContent = `${data.onlineCount} online, ${data.total} total`;
+        data.contacts.forEach((contact) => {
+          const item = document.createElement('div');
+          item.className = 'list-item';
+          item.innerHTML = `
+            <div>
+              <strong>${contact.displayName || contact.username}</strong>
+              <div class="badge">
+                <span class="status-dot ${contact.online ? 'online' : 'offline'}"></span>
+                ${contact.online ? 'Online' : 'Offline'}
+              </div>
+            </div>
+            <button class="secondary" data-username="${contact.username}">Chat</button>
+          `;
+          item.querySelector('button').addEventListener('click', () => {
+            window.location.href = `chat.html?to=${encodeURIComponent(contact.username)}`;
+          });
+          list.appendChild(item);
+        });
+      }
+
+      async function loadQr() {
+        const blob = await api('/api/qr/me');
+        const url = URL.createObjectURL(blob);
+        qr.innerHTML = `<img src="${url}" alt="QR code" />`;
+      }
+
+      form.addEventListener('submit', async (event) => {
+        event.preventDefault();
+        const username = document.getElementById('username').value.trim();
+        if (!username) return;
+        try {
+          await addContact(username);
+          document.getElementById('username').value = '';
+          await loadContacts();
+        } catch (error) {
+          alert(error.message || 'Unable to add contact');
+        }
+      });
+
+      connectPresenceSocket((payload) => {
+        payload.users.forEach((user) => {
+          const item = [...list.children].find((child) => child.querySelector('button').dataset.username === user.username);
+          if (item) {
+            const badge = item.querySelector('.badge');
+            badge.innerHTML = `<span class="status-dot ${user.online ? 'online' : 'offline'}"></span> ${user.online ? 'Online' : 'Offline'}`;
+          }
+        });
+      });
+
+      document.getElementById('logout-link').addEventListener('click', (event) => {
+        event.preventDefault();
+        logout();
+      });
+
+      await loadContacts();
+      await loadQr();
+    </script>
+  </body>
+</html>

--- a/enclypse/frontend/login.html
+++ b/enclypse/frontend/login.html
@@ -1,0 +1,42 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <title>Enclypse – Login</title>
+    <link rel="stylesheet" href="style.css" />
+  </head>
+  <body>
+    <main>
+      <nav>
+        <a href="login.html" class="active">Login</a>
+        <a href="register.html">Register</a>
+      </nav>
+      <section class="card">
+        <h1>Welcome back to Enclypse</h1>
+        <p class="badge">Privacy-first messaging</p>
+        <form id="login-form">
+          <input type="text" id="username" placeholder="Username" required />
+          <input type="password" id="password" placeholder="Password" required />
+          <button type="submit">Log in</button>
+        </form>
+        <p>Need an account? <a href="register.html">Create one here</a>.</p>
+      </section>
+    </main>
+    <script type="module">
+      import { login } from './common.js';
+
+      const form = document.getElementById('login-form');
+      form.addEventListener('submit', async (event) => {
+        event.preventDefault();
+        const username = document.getElementById('username').value.trim();
+        const password = document.getElementById('password').value;
+        try {
+          await login({ username, password });
+          window.location.href = 'sphere.html';
+        } catch (error) {
+          alert(error.message || 'Login failed');
+        }
+      });
+    </script>
+  </body>
+</html>

--- a/enclypse/frontend/profile.html
+++ b/enclypse/frontend/profile.html
@@ -1,0 +1,145 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <title>Enclypse – Profile</title>
+    <link rel="stylesheet" href="style.css" />
+  </head>
+  <body>
+    <main>
+      <nav>
+        <a href="sphere.html">Sphere</a>
+        <a href="contacts.html">Contacts</a>
+        <a href="search.html">Search</a>
+        <a href="chat.html">Chat</a>
+        <a href="profile.html" class="active">Profile</a>
+        <a href="#" id="logout-link">Logout</a>
+      </nav>
+      <section class="card profile-card" id="profile-card">
+        <h1>Loading profile…</h1>
+      </section>
+    </main>
+    <script type="module">
+      import { api, logout, savePreferences } from './common.js';
+
+      const params = new URLSearchParams(window.location.search);
+      const username = params.get('user');
+      const card = document.getElementById('profile-card');
+      let preferences = null;
+      let currentUser = null;
+
+      function applyTheme(theme) {
+        document.body.dataset.theme = theme || 'default';
+      }
+
+      function renderProfile(data, isSelf) {
+        const theme = data.preferences?.theme || preferences?.theme || 'default';
+        applyTheme(theme);
+        const avatar = (data.preferences && data.preferences.avatar) || preferences?.avatar || '';
+        const avatarMarkup = avatar
+          ? `<div class="avatar-preview animate"><img src="${avatar}" alt="${data.username} avatar" /></div>`
+          : '<div class="avatar-preview placeholder">🌌</div>';
+        const about = data.bio || 'No bio yet.';
+        card.innerHTML = `
+          <div class="profile-header">
+            ${avatarMarkup}
+            <div class="profile-meta">
+              <h1>${data.displayName || data.username}</h1>
+              <p class="badge"><span class="status-dot ${data.online ? 'online' : 'offline'}"></span> ${data.online ? 'Online' : 'Offline'}</p>
+              <p><strong>Username:</strong> ${data.username}</p>
+              <p><strong>Joined:</strong> ${new Date(data.createdAt).toLocaleString()}</p>
+              <p><strong>About:</strong> ${about}</p>
+            </div>
+          </div>
+          ${isSelf ? renderPreferencesForm(preferences || data.preferences || {}) : ''}
+        `;
+        if (isSelf) {
+          wirePreferencesForm();
+        }
+      }
+
+      function renderPreferencesForm(current) {
+        return `
+          <form id="preferences-form" class="preferences-form">
+            <h2>Personalization</h2>
+            <label>
+              <span>Theme</span>
+              <select id="pref-theme">
+                <option value="default" ${current.theme === 'default' ? 'selected' : ''}>Aurora default</option>
+                <option value="tron" ${current.theme === 'tron' ? 'selected' : ''}>Tron grid</option>
+                <option value="galaxy" ${current.theme === 'galaxy' ? 'selected' : ''}>Cosmic galaxy</option>
+                <option value="whiteboard" ${current.theme === 'whiteboard' ? 'selected' : ''}>Minimal whiteboard</option>
+              </select>
+            </label>
+            <label>
+              <span>Animated avatar URL</span>
+              <input type="url" id="pref-avatar" placeholder="https://" value="${current.avatar || ''}" />
+            </label>
+            <label class="checkbox">
+              <input type="checkbox" id="pref-ai" ${current.aiSidekick ? 'checked' : ''} /> Enable local AI sidekick boosts
+            </label>
+            <label class="checkbox">
+              <input type="checkbox" id="pref-trails" ${current.trailsEnabled !== false ? 'checked' : ''} /> Show presence trails across the sphere
+            </label>
+            <h2>Presence chimes</h2>
+            <label class="checkbox">
+              <input type="checkbox" id="pref-sound" ${current.soundEnabled ? 'checked' : ''} /> Play a chime when a friend appears
+            </label>
+            <label>
+              <span>Friend handle for chime</span>
+              <input type="text" id="pref-sound-contact" placeholder="friend username" value="${current.soundContact || ''}" />
+            </label>
+            <button type="submit">Save preferences</button>
+            <p class="badge" id="preferences-status">Preferences update instantly and stay on-device.</p>
+          </form>
+        `;
+      }
+
+      function wirePreferencesForm() {
+        const form = document.getElementById('preferences-form');
+        if (!form) return;
+        form.addEventListener('submit', async (event) => {
+          event.preventDefault();
+          const payload = {
+            theme: document.getElementById('pref-theme').value,
+            avatar: document.getElementById('pref-avatar').value.trim(),
+            aiSidekick: document.getElementById('pref-ai').checked,
+            trailsEnabled: document.getElementById('pref-trails').checked,
+            soundEnabled: document.getElementById('pref-sound').checked,
+            soundContact: document.getElementById('pref-sound-contact').value.trim(),
+          };
+          try {
+            preferences = await savePreferences(payload);
+            applyTheme(preferences.theme);
+            document.getElementById('preferences-status').textContent = 'Saved! Theme and trails updated.';
+          } catch (error) {
+            document.getElementById('preferences-status').textContent = error.message || 'Unable to save preferences';
+          }
+        });
+      }
+
+      async function loadProfile() {
+        try {
+          if (!username) {
+            const me = await api('/api/me');
+            currentUser = me.username;
+            preferences = me.preferences || {};
+            renderProfile(me, true);
+          } else {
+            const data = await api(`/api/users/${encodeURIComponent(username)}`);
+            renderProfile(data, false);
+          }
+        } catch (error) {
+          card.innerHTML = `<p class="badge">${error.message || 'Unable to load profile.'}</p>`;
+        }
+      }
+
+      document.getElementById('logout-link').addEventListener('click', (event) => {
+        event.preventDefault();
+        logout();
+      });
+
+      await loadProfile();
+    </script>
+  </body>
+</html>

--- a/enclypse/frontend/register.html
+++ b/enclypse/frontend/register.html
@@ -1,0 +1,45 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <title>Enclypse – Register</title>
+    <link rel="stylesheet" href="style.css" />
+  </head>
+  <body>
+    <main>
+      <nav>
+        <a href="login.html">Login</a>
+        <a href="register.html" class="active">Register</a>
+      </nav>
+      <section class="card">
+        <h1>Create your Enclypse account</h1>
+        <form id="register-form">
+          <input type="text" id="username" placeholder="Username" required />
+          <input type="text" id="display-name" placeholder="Display name" />
+          <input type="password" id="password" placeholder="Password" required />
+          <button type="submit">Create account</button>
+        </form>
+        <p>Already registered? <a href="login.html">Log in here</a>.</p>
+      </section>
+    </main>
+    <script type="module">
+      import { registerUser } from './common.js';
+
+      const form = document.getElementById('register-form');
+      form.addEventListener('submit', async (event) => {
+        event.preventDefault();
+        const username = document.getElementById('username').value.trim();
+        const displayName = document.getElementById('display-name').value.trim();
+        const password = document.getElementById('password').value;
+
+        try {
+          await registerUser({ username, password, displayName });
+          alert('Account created. You can now log in.');
+          window.location.href = 'login.html';
+        } catch (error) {
+          alert(error.message || 'Unable to register');
+        }
+      });
+    </script>
+  </body>
+</html>

--- a/enclypse/frontend/search.html
+++ b/enclypse/frontend/search.html
@@ -1,0 +1,84 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <title>Enclypse – Search</title>
+    <link rel="stylesheet" href="style.css" />
+  </head>
+  <body>
+    <main>
+      <nav>
+        <a href="sphere.html">Sphere</a>
+        <a href="contacts.html">Contacts</a>
+        <a href="search.html" class="active">Search</a>
+        <a href="chat.html">Chat</a>
+        <a href="profile.html">Profile</a>
+        <a href="#" id="logout-link">Logout</a>
+      </nav>
+      <section class="card">
+        <h1>Discover people</h1>
+        <input type="search" id="search" placeholder="Search by username or display name" />
+        <div class="list" id="results"></div>
+      </section>
+    </main>
+    <script type="module">
+      import { searchUsers, connectPresenceSocket, logout } from './common.js';
+
+      const input = document.getElementById('search');
+      const results = document.getElementById('results');
+
+      async function runSearch() {
+        const query = input.value.trim();
+        if (!query) {
+          results.innerHTML = '<p class="badge">Type to search Enclypse.</p>';
+          return;
+        }
+        const data = await searchUsers(query);
+        if (!data.results.length) {
+          results.innerHTML = '<p class="badge">No results.</p>';
+          return;
+        }
+        results.innerHTML = '';
+        data.results.forEach((user) => {
+          const item = document.createElement('div');
+          item.className = 'list-item';
+          item.innerHTML = `
+            <div>
+              <strong>${user.displayName || user.username}</strong>
+              <p class="badge">
+                <span class="status-dot ${user.online ? 'online' : 'offline'}"></span>
+                ${user.online ? 'Online' : 'Offline'}
+              </p>
+            </div>
+            <button class="secondary" data-username="${user.username}">View</button>
+          `;
+          item.querySelector('button').addEventListener('click', () => {
+            window.location.href = `profile.html?user=${encodeURIComponent(user.username)}`;
+          });
+          results.appendChild(item);
+        });
+      }
+
+      let debounce;
+      input.addEventListener('input', () => {
+        clearTimeout(debounce);
+        debounce = setTimeout(runSearch, 250);
+      });
+
+      connectPresenceSocket((payload) => {
+        [...results.children].forEach((child) => {
+          const username = child.querySelector('button').dataset.username;
+          const user = payload.users.find((u) => u.username === username);
+          if (user) {
+            child.querySelector('.badge').innerHTML = `<span class="status-dot ${user.online ? 'online' : 'offline'}"></span> ${user.online ? 'Online' : 'Offline'}`;
+          }
+        });
+      });
+
+      document.getElementById('logout-link').addEventListener('click', (event) => {
+        event.preventDefault();
+        logout();
+      });
+    </script>
+  </body>
+</html>

--- a/enclypse/frontend/sphere.html
+++ b/enclypse/frontend/sphere.html
@@ -1,0 +1,396 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <title>Enclypse – Presence Sphere</title>
+    <link rel="stylesheet" href="style.css" />
+    <script src="https://unpkg.com/three@0.161.0/build/three.min.js"></script>
+    <script src="https://unpkg.com/three@0.161.0/examples/js/controls/OrbitControls.js"></script>
+  </head>
+  <body>
+    <main>
+      <nav>
+        <a href="sphere.html" class="active">Sphere</a>
+        <a href="contacts.html">Contacts</a>
+        <a href="search.html">Search</a>
+        <a href="chat.html">Chat</a>
+        <a href="profile.html">Profile</a>
+        <a href="#" id="logout-link">Logout</a>
+      </nav>
+      <section class="card">
+        <h1>Enclypse Presence Sphere</h1>
+        <p class="badge">Live map of your network</p>
+        <div class="sphere-wrapper">
+          <canvas id="sphere-canvas"></canvas>
+        </div>
+      </section>
+    </main>
+    <script type="module">
+      import { getPresence, connectPresenceSocket, logout, createSecretLink, api } from './common.js';
+
+      const canvas = document.getElementById('sphere-canvas');
+      const renderer = new THREE.WebGLRenderer({ canvas, antialias: true, alpha: true });
+      const scene = new THREE.Scene();
+      const camera = new THREE.PerspectiveCamera(45, 1, 0.1, 1000);
+      const controls = new THREE.OrbitControls(camera, renderer.domElement);
+      const nodes = new Map();
+      const avatarSprites = new Map();
+      const trailLines = new Map();
+      const constellationLines = new Map();
+      const textureLoader = new THREE.TextureLoader();
+      const themePalette = {
+        default: 0x38bdf8,
+        tron: 0x22d3ee,
+        galaxy: 0xc084fc,
+        whiteboard: 0x3b82f6,
+      };
+
+      let currentUser = null;
+      let selfPreferences = {};
+      let currentPreferencesMap = {};
+      let previousOnline = new Set();
+      let intersected;
+      let lastPointerEvent = null;
+      const linkSelection = [];
+      let audioCtx;
+
+      camera.position.z = 6;
+      controls.enableDamping = true;
+
+      const light = new THREE.PointLight(0xffffff, 1.6);
+      light.position.set(5, 5, 5);
+      scene.add(light);
+
+      const ambient = new THREE.AmbientLight(0x406080, 0.5);
+      scene.add(ambient);
+
+      const sphereGeometry = new THREE.SphereGeometry(2.2, 32, 32);
+      const sphereMaterial = new THREE.MeshBasicMaterial({ wireframe: true, opacity: 0.2, transparent: true, color: 0x38bdf8 });
+      const sphereMesh = new THREE.Mesh(sphereGeometry, sphereMaterial);
+      scene.add(sphereMesh);
+
+      function applyTheme(theme) {
+        document.body.dataset.theme = theme || 'default';
+      }
+
+      async function loadSelf() {
+        try {
+          const me = await api('/api/me');
+          currentUser = me.username;
+          selfPreferences = me.preferences || {};
+          applyTheme(selfPreferences.theme);
+        } catch (error) {
+          console.warn('Unable to load self preferences', error);
+        }
+      }
+
+      function resize() {
+        const rect = renderer.domElement.getBoundingClientRect();
+        renderer.setSize(rect.width || window.innerWidth * 0.8, rect.height || 500, false);
+        camera.aspect = (rect.width || 1) / (rect.height || 1);
+        camera.updateProjectionMatrix();
+      }
+
+      const raycaster = new THREE.Raycaster();
+      const pointer = new THREE.Vector2();
+
+      function onPointerMove(event) {
+        lastPointerEvent = event;
+        const rect = renderer.domElement.getBoundingClientRect();
+        pointer.x = ((event.clientX - rect.left) / rect.width) * 2 - 1;
+        pointer.y = -((event.clientY - rect.top) / rect.height) * 2 + 1;
+      }
+
+      function highlightSelection() {
+        nodes.forEach((entry, username) => {
+          const selected = linkSelection.includes(username);
+          entry.mesh.scale.setScalar(selected ? 1.4 : 1);
+        });
+      }
+
+      function clearSelection() {
+        linkSelection.length = 0;
+        highlightSelection();
+      }
+
+      async function handleSecretLinkSelection(username) {
+        if (!username) return;
+        if (linkSelection.includes(username)) {
+          clearSelection();
+          return;
+        }
+        linkSelection.push(username);
+        highlightSelection();
+        if (linkSelection.length === 2) {
+          const [first, second] = linkSelection;
+          const label = prompt('Name this secret room', `${first} ↔ ${second}`);
+          if (label) {
+            const clue = prompt('Drop a hidden clue or URL');
+            if (clue !== null) {
+              try {
+                const nonceBytes = window.crypto.getRandomValues(new Uint8Array(24));
+                const nonce = btoa(String.fromCharCode(...nonceBytes));
+                const cipher = btoa(unescape(encodeURIComponent(clue)));
+                await createSecretLink({ label, cipher, nonce, audience: [first, second] });
+                alert('Secret room anchored between nodes!');
+              } catch (error) {
+                alert(error.message || 'Unable to craft secret link');
+              }
+            }
+          }
+          clearSelection();
+        }
+      }
+
+      function onClick(event) {
+        if (!intersected) return;
+        const { username } = intersected.userData || {};
+        if (!username) return;
+        if (event.metaKey || event.ctrlKey) {
+          handleSecretLinkSelection(username);
+        } else {
+          window.location.href = `chat.html?to=${encodeURIComponent(username)}`;
+        }
+      }
+
+      renderer.domElement.addEventListener('pointermove', onPointerMove);
+      renderer.domElement.addEventListener('click', onClick);
+      window.addEventListener('resize', resize);
+      resize();
+
+      function ensureAvatar(username, url) {
+        const entry = nodes.get(username);
+        if (!entry) return;
+        if (!url) {
+          const sprite = avatarSprites.get(username);
+          if (sprite) {
+            scene.remove(sprite);
+            avatarSprites.delete(username);
+          }
+          return;
+        }
+        if (avatarSprites.has(username) && avatarSprites.get(username).userData.url === url) {
+          const sprite = avatarSprites.get(username);
+          sprite.position.copy(entry.mesh.position).add(new THREE.Vector3(0, 0.3, 0));
+          return;
+        }
+        textureLoader.load(
+          url,
+          (texture) => {
+            const material = new THREE.SpriteMaterial({ map: texture, transparent: true });
+            const sprite = new THREE.Sprite(material);
+            sprite.scale.set(0.45, 0.45, 0.45);
+            sprite.position.copy(entry.mesh.position).add(new THREE.Vector3(0, 0.3, 0));
+            sprite.userData = { url };
+            avatarSprites.set(username, sprite);
+            scene.add(sprite);
+          },
+          undefined,
+          () => {
+            console.warn('Failed to load avatar', url);
+          },
+        );
+      }
+
+      function removeMissingNodes(activeUsernames) {
+        const activeSet = new Set(activeUsernames);
+        nodes.forEach((entry, username) => {
+          if (!activeSet.has(username)) {
+            scene.remove(entry.mesh);
+            entry.mesh.geometry.dispose();
+            entry.mesh.material.dispose();
+            nodes.delete(username);
+          }
+        });
+        avatarSprites.forEach((sprite, username) => {
+          if (!activeSet.has(username)) {
+            scene.remove(sprite);
+            avatarSprites.delete(username);
+          }
+        });
+        trailLines.forEach((line, username) => {
+          if (!activeSet.has(username)) {
+            scene.remove(line);
+            line.geometry.dispose();
+            line.material.dispose();
+            trailLines.delete(username);
+          }
+        });
+      }
+
+      function updateNodes(users) {
+        const total = users.length || 1;
+        users.forEach((user, idx) => {
+          const paletteKey = currentPreferencesMap[user.username]?.theme || 'default';
+          const baseColor = themePalette[paletteKey] || themePalette.default;
+          let entry = nodes.get(user.username);
+          if (!entry) {
+            const geometry = new THREE.SphereGeometry(0.13, 18, 18);
+            const material = new THREE.MeshStandardMaterial({ color: baseColor, emissive: baseColor, emissiveIntensity: 0.5 });
+            const mesh = new THREE.Mesh(geometry, material);
+            scene.add(mesh);
+            entry = { mesh };
+            nodes.set(user.username, entry);
+          }
+          entry.mesh.material.color.setHex(baseColor);
+          entry.mesh.material.emissive.setHex(baseColor);
+          entry.mesh.material.emissiveIntensity = user.online ? 0.6 : 0.2;
+          const phi = Math.acos(-1 + (2 * idx) / total);
+          const theta = Math.sqrt(total * Math.PI) * phi;
+          entry.mesh.position.set(
+            2.2 * Math.cos(theta) * Math.sin(phi),
+            2.2 * Math.sin(theta) * Math.sin(phi),
+            2.2 * Math.cos(phi),
+          );
+          entry.mesh.scale.setScalar(linkSelection.includes(user.username) ? 1.4 : 1);
+          entry.mesh.userData = user;
+          ensureAvatar(user.username, currentPreferencesMap[user.username]?.avatar);
+        });
+        removeMissingNodes(users.map((u) => u.username));
+      }
+
+      function updateTrails(trails) {
+        const usernames = Object.keys(trails || {});
+        const activeSet = new Set(usernames);
+        trailLines.forEach((line, username) => {
+          if (!activeSet.has(username)) {
+            scene.remove(line);
+            line.geometry.dispose();
+            line.material.dispose();
+            trailLines.delete(username);
+          }
+        });
+        usernames.forEach((username) => {
+          const points = trails[username] || [];
+          if (points.length < 2) return;
+          const node = nodes.get(username);
+          if (!node) return;
+          const vectorPoints = points.map((point) => new THREE.Vector3(point.x, point.y, point.z));
+          const geometry = new THREE.BufferGeometry().setFromPoints(vectorPoints);
+          const paletteKey = currentPreferencesMap[username]?.theme || 'default';
+          const color = themePalette[paletteKey] || 0x94a3b8;
+          const material = new THREE.LineBasicMaterial({ color, transparent: true, opacity: 0.35 });
+          if (trailLines.has(username)) {
+            const existing = trailLines.get(username);
+            scene.remove(existing);
+            existing.geometry.dispose();
+            existing.material.dispose();
+          }
+          const line = new THREE.Line(geometry, material);
+          scene.add(line);
+          trailLines.set(username, line);
+        });
+      }
+
+      function updateConstellations(constellations) {
+        constellationLines.forEach((group) => {
+          group.children.forEach((child) => {
+            child.geometry.dispose();
+            child.material.dispose();
+          });
+          scene.remove(group);
+        });
+        constellationLines.clear();
+        constellations.forEach((constellation) => {
+          const group = new THREE.Group();
+          constellation.links.forEach((link) => {
+            const fromNode = nodes.get(link.from);
+            const toNode = nodes.get(link.to);
+            if (!fromNode || !toNode) return;
+            const geometry = new THREE.BufferGeometry().setFromPoints([
+              fromNode.mesh.position.clone(),
+              toNode.mesh.position.clone(),
+            ]);
+            const ownerTheme = currentPreferencesMap[constellation.owner]?.theme || 'default';
+            const color = themePalette[ownerTheme] || 0x94a3b8;
+            const material = new THREE.LineDashedMaterial({ color, transparent: true, opacity: 0.4, dashSize: 0.12, gapSize: 0.1 });
+            const line = new THREE.Line(geometry, material);
+            line.computeLineDistances();
+            group.add(line);
+          });
+          scene.add(group);
+          constellationLines.set(constellation.id, group);
+        });
+      }
+
+      function playPresenceChime() {
+        if (!audioCtx) {
+          audioCtx = new (window.AudioContext || window.webkitAudioContext)();
+        }
+        const oscillator = audioCtx.createOscillator();
+        const gain = audioCtx.createGain();
+        oscillator.type = 'sine';
+        oscillator.frequency.setValueAtTime(880, audioCtx.currentTime);
+        gain.gain.setValueAtTime(0.001, audioCtx.currentTime);
+        gain.gain.exponentialRampToValueAtTime(0.12, audioCtx.currentTime + 0.01);
+        gain.gain.exponentialRampToValueAtTime(0.0001, audioCtx.currentTime + 0.6);
+        oscillator.connect(gain).connect(audioCtx.destination);
+        oscillator.start();
+        oscillator.stop(audioCtx.currentTime + 0.65);
+      }
+
+      function handleChimes(users) {
+        if (!selfPreferences?.soundEnabled || !selfPreferences.soundContact) return;
+        const newOnline = new Set(users.filter((u) => u.online).map((u) => u.username));
+        if (!previousOnline.has(selfPreferences.soundContact) && newOnline.has(selfPreferences.soundContact)) {
+          playPresenceChime();
+        }
+        previousOnline = newOnline;
+      }
+
+      function updateScene(payload) {
+        if (!payload) return;
+        currentPreferencesMap = payload.preferences || {};
+        if (currentUser && currentPreferencesMap[currentUser]?.theme && currentPreferencesMap[currentUser].theme !== selfPreferences.theme) {
+          selfPreferences.theme = currentPreferencesMap[currentUser].theme;
+          applyTheme(selfPreferences.theme);
+        }
+        updateNodes(payload.users || []);
+        updateTrails(payload.trails || {});
+        updateConstellations(payload.constellations || []);
+        handleChimes(payload.users || []);
+      }
+
+      async function loadPresence() {
+        try {
+          const data = await getPresence();
+          updateScene(data);
+        } catch (error) {
+          console.error('Failed to load presence', error);
+        }
+      }
+
+      connectPresenceSocket((payload) => {
+        updateScene(payload);
+      });
+
+      document.getElementById('logout-link').addEventListener('click', (event) => {
+        event.preventDefault();
+        logout();
+      });
+
+      function animate() {
+        requestAnimationFrame(animate);
+        raycaster.setFromCamera(pointer, camera);
+        const intersects = raycaster.intersectObjects([...nodes.values()].map((entry) => entry.mesh));
+        if (intersects.length) {
+          intersected = intersects[0].object;
+          document.body.style.cursor = 'pointer';
+        } else {
+          intersected = null;
+          document.body.style.cursor = 'default';
+        }
+        avatarSprites.forEach((sprite) => {
+          sprite.position.y += Math.sin(Date.now() * 0.0015) * 0.0008;
+        });
+        sphereMesh.rotation.y += 0.0006;
+        controls.update();
+        renderer.render(scene, camera);
+      }
+
+      await loadSelf();
+      await loadPresence();
+      animate();
+    </script>
+  </body>
+</html>

--- a/enclypse/frontend/style.css
+++ b/enclypse/frontend/style.css
@@ -1,0 +1,955 @@
+:root {
+  --bg: #0f172a;
+  --card: rgba(15, 23, 42, 0.8);
+  --primary: #38bdf8;
+  --danger: #f87171;
+  --success: #4ade80;
+  --text: #e2e8f0;
+  --muted: #94a3b8;
+  --border: rgba(148, 163, 184, 0.2);
+  --shadow: 0 20px 45px rgba(15, 23, 42, 0.45);
+  font-family: 'Inter', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+}
+
+body[data-theme='tron'] {
+  --bg: #050816;
+  --card: rgba(5, 8, 22, 0.85);
+  --primary: #22d3ee;
+  --text: #e2f3ff;
+  --muted: #7dd3fc;
+  --border: rgba(34, 211, 238, 0.25);
+  --shadow: 0 28px 55px rgba(34, 211, 238, 0.22);
+}
+
+body[data-theme='galaxy'] {
+  --bg: #0b1120;
+  --card: rgba(30, 41, 59, 0.85);
+  --primary: #c084fc;
+  --text: #f8fafc;
+  --muted: #d8b4fe;
+  --border: rgba(192, 132, 252, 0.3);
+  --shadow: 0 26px 50px rgba(192, 132, 252, 0.18);
+}
+
+body[data-theme='whiteboard'] {
+  --bg: #f8fafc;
+  --card: rgba(255, 255, 255, 0.92);
+  --primary: #3b82f6;
+  --text: #0f172a;
+  --muted: #475569;
+  --border: rgba(148, 163, 184, 0.35);
+  --shadow: 0 18px 40px rgba(15, 23, 42, 0.12);
+  color: #0f172a;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  background: radial-gradient(circle at top left, #1e293b, var(--bg) 40%);
+  color: var(--text);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 2rem;
+}
+
+body[data-theme='whiteboard'] {
+  background: linear-gradient(180deg, #f8fafc, #e2e8f0);
+}
+
+main {
+  width: min(960px, 100%);
+  background: linear-gradient(145deg, rgba(30, 41, 59, 0.9), rgba(15, 23, 42, 0.92));
+  border: 1px solid var(--border);
+  border-radius: 28px;
+  box-shadow: var(--shadow);
+  padding: 3rem;
+  backdrop-filter: blur(18px);
+}
+
+body[data-theme='whiteboard'] main {
+  background: linear-gradient(145deg, rgba(255, 255, 255, 0.95), rgba(226, 232, 240, 0.9));
+}
+
+h1, h2, h3 {
+  color: white;
+  margin-top: 0;
+  letter-spacing: -0.01em;
+}
+
+a {
+  color: var(--primary);
+  text-decoration: none;
+}
+
+a:hover {
+  text-decoration: underline;
+}
+
+button {
+  background: var(--primary);
+  border: none;
+  color: #0f172a;
+  padding: 0.8rem 1.4rem;
+  border-radius: 999px;
+  font-weight: 600;
+  cursor: pointer;
+  box-shadow: 0 15px 35px rgba(56, 189, 248, 0.25);
+  transition: transform 0.15s ease, box-shadow 0.15s ease;
+}
+
+button.danger {
+  background: var(--danger);
+  box-shadow: 0 15px 35px rgba(248, 113, 113, 0.25);
+}
+
+button.secondary {
+  background: rgba(56, 189, 248, 0.12);
+  color: var(--primary);
+  box-shadow: none;
+}
+
+button:hover {
+  transform: translateY(-1px);
+  box-shadow: 0 20px 45px rgba(56, 189, 248, 0.35);
+}
+
+input, textarea {
+  width: 100%;
+  padding: 0.85rem 1rem;
+  border-radius: 16px;
+  border: 1px solid var(--border);
+  background: rgba(15, 23, 42, 0.7);
+  color: white;
+  font-size: 1rem;
+  margin-bottom: 1rem;
+  transition: border 0.2s ease, background 0.2s ease;
+}
+
+input:focus, textarea:focus {
+  border-color: var(--primary);
+  outline: none;
+  background: rgba(15, 23, 42, 0.9);
+}
+
+.card {
+  background: var(--card);
+  border: 1px solid var(--border);
+  border-radius: 24px;
+  padding: 2rem;
+  box-shadow: var(--shadow);
+}
+
+.row {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+  gap: 1.5rem;
+  align-items: start;
+}
+
+nav {
+  display: flex;
+  gap: 0.75rem;
+  flex-wrap: wrap;
+  margin-bottom: 2rem;
+}
+
+nav a {
+  padding: 0.6rem 1.2rem;
+  border-radius: 999px;
+  border: 1px solid transparent;
+  background: rgba(148, 163, 184, 0.1);
+  color: var(--text);
+  font-weight: 500;
+}
+
+nav a.active {
+  border-color: var(--primary);
+  color: var(--primary);
+  background: rgba(56, 189, 248, 0.15);
+}
+
+.badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+  padding: 0.3rem 0.65rem;
+  font-size: 0.75rem;
+  border-radius: 999px;
+  background: rgba(148, 163, 184, 0.18);
+  color: var(--muted);
+}
+
+.badge.success {
+  background: rgba(74, 222, 128, 0.15);
+  color: var(--success);
+}
+
+.badge.warning {
+  background: rgba(250, 204, 21, 0.2);
+  color: #facc15;
+}
+
+.badge.filter {
+  background: rgba(129, 140, 248, 0.18);
+  color: #a5b4fc;
+  border: 1px solid rgba(129, 140, 248, 0.35);
+}
+
+.status-dot {
+  display: inline-flex;
+  width: 10px;
+  height: 10px;
+  border-radius: 999px;
+}
+
+.status-dot.online {
+  background: var(--success);
+  box-shadow: 0 0 12px rgba(74, 222, 128, 0.5);
+}
+
+.status-dot.offline {
+  background: var(--danger);
+  box-shadow: 0 0 12px rgba(248, 113, 113, 0.5);
+}
+
+.list {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.list-item {
+  padding: 1rem 1.2rem;
+  background: rgba(15, 23, 42, 0.65);
+  border: 1px solid var(--border);
+  border-radius: 18px;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 1rem;
+}
+
+.list-item strong {
+  font-size: 1.05rem;
+}
+
+.channel-toggle {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 1rem;
+  gap: 1rem;
+}
+
+.channel-toggle label {
+  font-weight: 600;
+  color: var(--muted);
+}
+
+.channel-controls {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+}
+
+.channel-controls select {
+  appearance: none;
+  background: rgba(15, 23, 42, 0.65);
+  border: 1px solid var(--border);
+  color: var(--text);
+  padding: 0.45rem 0.8rem;
+  border-radius: 12px;
+  font-size: 0.9rem;
+}
+
+.chat-card {
+  display: flex;
+  flex-direction: column;
+  gap: 1.75rem;
+}
+
+.chat-columns {
+  display: grid;
+  grid-template-columns: minmax(0, 1.6fr) minmax(0, 1fr);
+  gap: 2rem;
+  align-items: start;
+}
+
+.chat-column {
+  display: flex;
+  flex-direction: column;
+  gap: 1.25rem;
+}
+
+.chat-side {
+  display: flex;
+  flex-direction: column;
+  gap: 1.2rem;
+  max-height: 560px;
+  overflow-y: auto;
+  padding-right: 0.4rem;
+}
+
+.profile-card {
+  display: flex;
+  flex-direction: column;
+  gap: 2rem;
+}
+
+.profile-header {
+  display: flex;
+  align-items: center;
+  gap: 1.5rem;
+}
+
+.avatar-preview {
+  width: 120px;
+  height: 120px;
+  border-radius: 50%;
+  border: 2px solid rgba(56, 189, 248, 0.45);
+  background: rgba(15, 23, 42, 0.75);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  overflow: hidden;
+  font-size: 2.5rem;
+}
+
+.avatar-preview.animate {
+  box-shadow: 0 0 25px rgba(56, 189, 248, 0.3);
+  animation: float 6s ease-in-out infinite;
+}
+
+.avatar-preview img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+}
+
+.profile-meta p {
+  margin: 0.3rem 0;
+}
+
+.preferences-form {
+  display: grid;
+  gap: 1rem;
+}
+
+.preferences-form h2 {
+  margin-bottom: 0;
+}
+
+.preferences-form label {
+  display: flex;
+  flex-direction: column;
+  gap: 0.4rem;
+  font-weight: 500;
+  color: var(--muted);
+}
+
+.preferences-form .checkbox {
+  flex-direction: row;
+  align-items: center;
+  gap: 0.6rem;
+}
+
+.preferences-form .checkbox input {
+  width: auto;
+  margin: 0;
+}
+
+.preferences-form button {
+  justify-self: start;
+}
+
+@keyframes float {
+  0%, 100% {
+    transform: translateY(0px);
+  }
+  50% {
+    transform: translateY(-6px);
+  }
+}
+
+@keyframes pulse-lock {
+  0%,
+  100% {
+    transform: scale(1);
+  }
+  50% {
+    transform: scale(1.15);
+  }
+}
+
+@keyframes orbit-glow {
+  0% {
+    box-shadow: 0 0 0 1px rgba(14, 165, 233, 0.3);
+  }
+  50% {
+    box-shadow: 0 0 0 6px rgba(14, 165, 233, 0.08);
+  }
+  100% {
+    box-shadow: 0 0 0 1px rgba(14, 165, 233, 0.3);
+  }
+}
+
+@keyframes pulse-wave {
+  0% {
+    box-shadow: 0 0 0 0 rgba(250, 204, 21, 0.4);
+  }
+  70% {
+    box-shadow: 0 0 0 10px rgba(250, 204, 21, 0);
+  }
+  100% {
+    box-shadow: 0 0 0 0 rgba(250, 204, 21, 0);
+  }
+}
+
+.chat-window {
+  display: flex;
+  flex-direction: column;
+  height: 520px;
+  border-radius: 20px;
+  overflow: hidden;
+  border: 1px solid var(--border);
+}
+
+.chat-flair {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1rem;
+  align-items: flex-end;
+  padding: 1rem;
+  border: 1px dashed rgba(148, 163, 184, 0.25);
+  border-radius: 18px;
+  background: rgba(15, 23, 42, 0.55);
+}
+
+.chat-flair label {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+  font-size: 0.85rem;
+  color: var(--muted);
+  font-weight: 500;
+}
+
+.toggle {
+  flex-direction: row;
+  gap: 0.5rem;
+  align-items: center;
+}
+
+.toggle input {
+  width: auto;
+  margin: 0;
+}
+
+.flair-inline {
+  display: flex;
+  gap: 0.5rem;
+  align-items: center;
+}
+
+.flair-inline input {
+  width: 80px;
+  margin-bottom: 0;
+}
+
+.flair-select select {
+  background: rgba(15, 23, 42, 0.7);
+  border: 1px solid var(--border);
+  color: var(--text);
+  padding: 0.5rem 0.75rem;
+  border-radius: 12px;
+}
+
+.flair-input input {
+  margin-bottom: 0;
+}
+
+.chat-messages {
+  flex: 1;
+  padding: 1.5rem;
+  overflow-y: auto;
+  display: flex;
+  flex-direction: column;
+  gap: 1.25rem;
+  background: rgba(15, 23, 42, 0.72);
+}
+
+.message {
+  max-width: 70%;
+  padding: 1rem 1.2rem;
+  border-radius: 20px;
+  position: relative;
+  line-height: 1.5;
+  display: flex;
+  flex-direction: column;
+  gap: 0.6rem;
+}
+
+.message .bubble {
+  margin: 0;
+  line-height: 1.6;
+}
+
+.secret-attachment {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+  align-items: flex-start;
+}
+
+.secret-attachment__button {
+  width: 100%;
+  justify-content: center;
+  position: relative;
+}
+
+.secret-attachment__hint {
+  display: flex;
+  align-items: center;
+  gap: 0.4rem;
+  font-size: 0.75rem;
+  color: rgba(148, 163, 184, 0.8);
+  transition: color 0.2s ease, opacity 0.2s ease;
+}
+
+.secret-attachment__hint::before {
+  content: '🔒';
+  display: inline-flex;
+  animation: pulse-lock 2.4s infinite;
+}
+
+.secret-attachment__hint--active {
+  color: #facc15;
+}
+
+.secret-attachment__hint--primed {
+  color: #34d399;
+}
+
+.secret-attachment--orbit .secret-attachment__button {
+  box-shadow: 0 0 0 1px rgba(14, 165, 233, 0.45);
+  animation: orbit-glow 3s infinite;
+}
+
+.secret-attachment__button[data-primed='true'] {
+  box-shadow: 0 0 0 2px rgba(52, 211, 153, 0.45);
+  color: #34d399;
+}
+
+.secret-attachment--prism .secret-attachment__button {
+  background: linear-gradient(120deg, rgba(56, 189, 248, 0.18), rgba(192, 132, 252, 0.2));
+}
+
+.secret-attachment--pulse .secret-attachment__button {
+  animation: pulse-wave 1.8s infinite;
+}
+
+.message-flair {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.4rem;
+}
+
+.message.sent {
+  align-self: flex-end;
+  background: rgba(56, 189, 248, 0.22);
+  border: 1px solid rgba(56, 189, 248, 0.35);
+}
+
+.message.received {
+  align-self: flex-start;
+  background: rgba(51, 65, 85, 0.8);
+  border: 1px solid rgba(148, 163, 184, 0.25);
+}
+
+.message small {
+  display: block;
+  margin-top: 0.45rem;
+  font-size: 0.75rem;
+  color: var(--muted);
+}
+
+.chat-input {
+  padding: 1.2rem;
+  background: rgba(15, 23, 42, 0.85);
+  border-top: 1px solid var(--border);
+  display: grid;
+  grid-template-columns: 1fr auto auto;
+  gap: 0.75rem;
+}
+
+.panel {
+  background: rgba(15, 23, 42, 0.65);
+  border: 1px solid var(--border);
+  border-radius: 20px;
+  padding: 1.25rem 1.4rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.panel header h2 {
+  margin-bottom: 0.2rem;
+}
+
+.panel header p {
+  margin: 0;
+  color: var(--muted);
+  font-size: 0.85rem;
+}
+
+.sidekick-controls,
+.game-controls,
+.album-uploader,
+.treasure-claim {
+  display: flex;
+  gap: 0.6rem;
+  flex-wrap: wrap;
+  align-items: center;
+}
+
+#sidekick-output {
+  background: rgba(15, 23, 42, 0.7);
+  border: 1px solid var(--border);
+  border-radius: 16px;
+  padding: 0.9rem 1rem;
+  font-size: 0.85rem;
+  color: var(--muted);
+  min-height: 120px;
+}
+
+.game-board {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 0.5rem;
+}
+
+.game-board--hidden {
+  display: none;
+}
+
+.game-instructions {
+  font-size: 0.85rem;
+  color: var(--muted);
+  margin: 0 0 0.5rem;
+}
+
+.game-board .cell {
+  height: 64px;
+  border-radius: 14px;
+  border: 1px solid var(--border);
+  background: rgba(30, 41, 59, 0.8);
+  color: var(--primary);
+  font-size: 1.5rem;
+  font-weight: 700;
+  box-shadow: none;
+}
+
+.game-board .cell:disabled {
+  opacity: 0.55;
+  cursor: not-allowed;
+}
+
+.game-actions {
+  display: flex;
+  gap: 0.6rem;
+  align-items: center;
+}
+
+.visually-hidden {
+  display: none !important;
+}
+
+.game-actions input {
+  margin-bottom: 0;
+  flex: 1;
+}
+
+.album-uploader input[type='file'] {
+  margin-bottom: 0;
+}
+
+.panel ul {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+#album-list li {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+  padding: 0.35rem 0.5rem;
+  border: 1px solid transparent;
+  border-radius: 12px;
+  cursor: pointer;
+  transition: border-color 0.2s ease, background 0.2s ease;
+}
+
+#album-list li strong {
+  font-weight: 600;
+}
+
+#album-list li small {
+  font-size: 0.75rem;
+  color: var(--muted);
+}
+
+#album-list li:hover {
+  border-color: rgba(56, 189, 248, 0.35);
+  background: rgba(56, 189, 248, 0.08);
+}
+
+#secret-link-list li small {
+  display: block;
+  font-size: 0.7rem;
+  color: rgba(148, 163, 184, 0.75);
+}
+
+.panel ul li {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 0.75rem;
+  padding: 0.75rem 1rem;
+  border: 1px solid var(--border);
+  border-radius: 14px;
+  background: rgba(15, 23, 42, 0.6);
+}
+
+.panel ul li div {
+  display: flex;
+  flex-direction: column;
+  gap: 0.2rem;
+}
+
+.panel ul li span {
+  color: var(--muted);
+  font-size: 0.8rem;
+}
+
+.panel ul li button {
+  padding: 0.4rem 0.75rem;
+  font-size: 0.75rem;
+}
+
+.panel ul li.empty {
+  justify-content: center;
+  color: var(--muted);
+}
+
+.treasure-claim input {
+  max-width: 160px;
+}
+
+.badge.glow {
+  background: rgba(217, 70, 239, 0.18);
+  color: #f0abfc;
+}
+
+.chat-input input[type="file"] {
+  display: none;
+}
+
+.file-label {
+  background: rgba(56, 189, 248, 0.12);
+  color: var(--primary);
+  border-radius: 12px;
+  padding: 0.65rem 1rem;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  cursor: pointer;
+  border: 1px dashed rgba(56, 189, 248, 0.35);
+}
+
+.qr-container {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 1.5rem;
+  align-items: center;
+}
+
+.qr-code {
+  background: white;
+  border-radius: 20px;
+  padding: 1.5rem;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.sphere-wrapper {
+  height: 540px;
+  border-radius: 24px;
+  border: 1px solid var(--border);
+  background: rgba(15, 23, 42, 0.65);
+  position: relative;
+  overflow: hidden;
+}
+
+canvas {
+  display: block;
+}
+
+@media (max-width: 768px) {
+  body {
+    padding: 1rem;
+  }
+
+  main {
+    padding: 2rem;
+  }
+
+  .chat-window {
+    height: 420px;
+  }
+
+  .chat-columns {
+    grid-template-columns: 1fr;
+  }
+
+  .chat-side {
+    max-height: none;
+  }
+}
+
+.album-lightbox {
+  position: fixed;
+  inset: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: rgba(15, 23, 42, 0.85);
+  backdrop-filter: blur(6px);
+  z-index: 60;
+  opacity: 0;
+  pointer-events: none;
+  transition: opacity 0.25s ease;
+}
+
+.album-lightbox.hidden {
+  display: none;
+}
+
+.album-lightbox.open {
+  opacity: 1;
+  pointer-events: auto;
+}
+
+.album-lightbox__dialog {
+  position: relative;
+  background: rgba(15, 23, 42, 0.95);
+  border: 1px solid rgba(56, 189, 248, 0.2);
+  border-radius: 24px;
+  padding: 1.2rem 1.4rem;
+  width: min(720px, 92vw);
+  max-height: 90vh;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  z-index: 1;
+}
+
+.album-lightbox__backdrop {
+  position: absolute;
+  inset: 0;
+  z-index: 0;
+}
+
+.album-lightbox__dismiss {
+  position: absolute;
+  top: 0.6rem;
+  right: 0.8rem;
+  border: none;
+  background: none;
+  font-size: 1.4rem;
+  color: var(--muted);
+  cursor: pointer;
+  transition: color 0.2s ease;
+}
+
+.album-lightbox__dismiss:hover {
+  color: var(--primary);
+}
+
+.album-lightbox__grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+  gap: 1rem;
+  overflow-y: auto;
+  padding-right: 0.4rem;
+}
+
+.album-lightbox__item {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.album-lightbox__item img {
+  width: 100%;
+  height: 160px;
+  object-fit: cover;
+  border-radius: 16px;
+  border: 1px solid rgba(148, 163, 184, 0.2);
+}
+
+.album-lightbox__item figcaption {
+  display: flex;
+  flex-direction: column;
+  gap: 0.15rem;
+  font-size: 0.8rem;
+  color: var(--muted);
+}
+
+.album-lightbox__item figcaption strong {
+  color: var(--text);
+}
+
+.album-lightbox__item figcaption time {
+  font-size: 0.7rem;
+  color: rgba(148, 163, 184, 0.7);
+}
+
+.album-lightbox__download {
+  display: inline-flex;
+  justify-content: center;
+  padding: 0.5rem 0.75rem;
+  border-radius: 12px;
+  border: 1px dashed rgba(148, 163, 184, 0.35);
+  color: var(--muted);
+  text-decoration: none;
+}
+
+.album-lightbox__download:hover {
+  border-color: rgba(56, 189, 248, 0.5);
+  color: var(--primary);
+}
+
+.album-lightbox__error {
+  padding: 0.75rem;
+  border-radius: 12px;
+  background: rgba(248, 113, 113, 0.12);
+  color: #fca5a5;
+  text-align: center;
+}
+
+.album-lightbox__grid .empty {
+  grid-column: 1 / -1;
+  text-align: center;
+  color: var(--muted);
+}
+

--- a/enclypse/scripts/dev.js
+++ b/enclypse/scripts/dev.js
@@ -1,0 +1,30 @@
+import { spawn } from 'child_process';
+
+const npmCmd = process.platform === 'win32' ? 'npm.cmd' : 'npm';
+
+function startProcess(name, args) {
+  const child = spawn(npmCmd, args, { stdio: 'inherit', env: process.env });
+  child.on('exit', (code) => {
+    if (code !== null && code !== 0) {
+      console.error(`[enclypse] ${name} exited with code ${code}`);
+    }
+    shutdown();
+  });
+  return child;
+}
+
+const backend = startProcess('backend', ['run', 'backend:start']);
+let electronProcess;
+
+setTimeout(() => {
+  electronProcess = startProcess('electron', ['run', 'electron:start']);
+}, 1500);
+
+function shutdown() {
+  if (backend && !backend.killed) backend.kill();
+  if (electronProcess && !electronProcess.killed) electronProcess.kill();
+  process.exit(0);
+}
+
+process.on('SIGINT', shutdown);
+process.on('SIGTERM', shutdown);

--- a/enclypse/scripts/setup.bat
+++ b/enclypse/scripts/setup.bat
@@ -1,0 +1,40 @@
+@echo off
+setlocal ENABLEDELAYEDEXPANSION
+
+set APP_NAME=enclypse
+set CONDA_ENV=enclypse-node
+
+where conda >nul 2>nul
+if %errorlevel% neq 0 (
+  echo [!] Miniconda or Anaconda is required. Please install it first.
+  exit /b 1
+)
+
+echo [+] Creating Conda environment %CONDA_ENV%
+conda env list | findstr /C:"%CONDA_ENV%" >nul 2>nul
+if %errorlevel% neq 0 (
+  call conda create -y -n %CONDA_ENV% nodejs=20 sqlite
+)
+
+call conda activate %CONDA_ENV%
+
+if not exist node_modules (
+  echo [+] Installing npm dependencies
+  call npm install
+)
+
+pushd enclypse\backend
+if not exist node_modules (
+  echo [+] Installing backend dependencies
+  call npm install
+)
+popd
+
+start "Enclypse Backend" cmd /k "cd /d %cd%\enclypse\backend && node server.js"
+
+ping 127.0.0.1 -n 5 >nul
+
+start "Enclypse Desktop" cmd /k "cd /d %cd% && npm run electron:start"
+
+echo [+] Enclypse stack launched.
+endlocal

--- a/package.json
+++ b/package.json
@@ -7,7 +7,10 @@
     "dev": "vite",
     "build": "vite build",
     "lint": "eslint .",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "backend:start": "node enclypse/backend/server.js",
+    "electron:start": "electron electron/main.js",
+    "enclypse": "node enclypse/scripts/dev.js"
   },
   "dependencies": {
     "@react-three/drei": "^9.99.0",
@@ -33,6 +36,7 @@
     "tailwindcss": "^3.4.1",
     "typescript": "^5.5.3",
     "typescript-eslint": "^8.3.0",
-    "vite": "^5.4.2"
+    "vite": "^5.4.2",
+    "electron": "^30.0.8"
   }
 }

--- a/src/components/Sphere.tsx
+++ b/src/components/Sphere.tsx
@@ -1,6 +1,6 @@
 import { useFrame } from '@react-three/fiber';
 import { useRef } from 'react';
-import { Mesh, Color, MathUtils } from 'three';
+import { Mesh, Color } from 'three';
 import { useThemeStore } from '../store/themeStore';
 
 const themeConfigs = {

--- a/src/components/chat/ChatWindow.tsx
+++ b/src/components/chat/ChatWindow.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useRef } from 'react';
+import { useState, useEffect, useRef, useMemo } from 'react';
 import { X, Send } from 'lucide-react';
 import { useChatStore } from '../../store/chatStore';
 import { useUserStore } from '../../store/userStore';
@@ -16,9 +16,10 @@ export function ChatWindow({ userId, onClose }: ChatWindowProps) {
   const otherUser = useUserStore((state) => state.users.find(u => u.id === userId));
   const { sendMessage, getMessagesForChat } = useChatStore();
 
-  const messages = currentUser 
-    ? getMessagesForChat(currentUser.id, userId)
-    : [];
+  const messages = useMemo(
+    () => (currentUser ? getMessagesForChat(currentUser.id, userId) : []),
+    [currentUser, userId, getMessagesForChat],
+  );
 
   const scrollToBottom = () => {
     messagesEndRef.current?.scrollIntoView({ behavior: 'smooth' });


### PR DESCRIPTION
## Summary
- add tactile hints and motion cues for secret-filtered attachments, updating chat UI and styles for clearer unlock flows
- introduce an encrypted album lightbox viewer with client-side decryption and supporting CSS/README notes
- store secret links with per-participant sealed keys via database/REST updates and refresh mini-game guidance in the chat module

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68defe7d6d388323abc56aa3599f267b