### PR TITLE
Adjust body overflow to restore vertical scrolling

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -8,7 +8,7 @@
 
 body {
   margin: 0;
-  overflow: hidden;
+  overflow-x: hidden;
 }
 
 canvas {


### PR DESCRIPTION
## Summary
- limit the global body overflow constraint to only hide horizontal overflow so the page can scroll vertically

## Testing
- npm run build


------
https://chatgpt.com/codex/tasks/task_e_68e1dba21c188323a732a6e4872d2058