### PR TITLE
Add explicit profile modal modes for view and edit

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -14,8 +14,9 @@ import { FieldNotesPanel } from './components/interface/FieldNotesPanel';
 
 export function App() {
   const isAuthenticated = useAuthStore((state) => state.isAuthenticated);
-  const profileUserId = useModalStore((state) => state.profileUserId);
-  const setProfileUserId = useModalStore((state) => state.setProfileUserId);
+  const profileModal = useModalStore((state) => state.profileModal);
+  const closeProfileModal = useModalStore((state) => state.closeProfileModal);
+  const setProfileModalMode = useModalStore((state) => state.setProfileModalMode);
   const activeChat = useChatStore((state) => state.activeChat);
   const setActiveChat = useChatStore((state) => state.setActiveChat);
   const currentTheme = useThemeStore((state) => state.currentTheme);
@@ -57,10 +58,12 @@ export function App() {
             <FieldNotesPanel />
           </main>
 
-          {profileUserId && (
+          {profileModal && (
             <ProfileModal
-              userId={profileUserId}
-              onClose={() => setProfileUserId(null)}
+              userId={profileModal.userId}
+              mode={profileModal.mode}
+              onClose={closeProfileModal}
+              onModeChange={setProfileModalMode}
             />
           )}
           {activeChat && (

--- a/src/components/ProfileIcon.tsx
+++ b/src/components/ProfileIcon.tsx
@@ -10,7 +10,7 @@ interface ProfileIconProps {
 export function ProfileIcon({ className }: ProfileIconProps) {
   const [isOpen, setIsOpen] = useState(false);
   const currentUser = useAuthStore((state) => state.user);
-  const { setProfileUserId } = useModalStore();
+  const openProfileModal = useModalStore((state) => state.openProfileModal);
 
   if (!currentUser) return null;
 
@@ -19,6 +19,7 @@ export function ProfileIcon({ className }: ProfileIconProps) {
       <button
         onClick={() => setIsOpen(!isOpen)}
         className="p-2 bg-white/10 backdrop-blur-md border border-white/10 rounded-lg text-white hover:bg-white/20 transition-colors flex items-center space-x-2"
+        aria-label="Open profile menu"
       >
         {currentUser.profilePicture ? (
           <img
@@ -35,7 +36,7 @@ export function ProfileIcon({ className }: ProfileIconProps) {
         <div className="absolute right-0 mt-2 w-48 bg-white/10 backdrop-blur-md border border-white/10 rounded-lg overflow-hidden z-30">
           <button
             onClick={() => {
-              setProfileUserId(currentUser.id);
+              openProfileModal(currentUser.id);
               setIsOpen(false);
             }}
             className="w-full px-4 py-2 text-left text-white hover:bg-white/10 transition-colors"
@@ -44,7 +45,7 @@ export function ProfileIcon({ className }: ProfileIconProps) {
           </button>
           <button
             onClick={() => {
-              setProfileUserId(currentUser.id);
+              openProfileModal(currentUser.id, 'edit');
               setIsOpen(false);
             }}
             className="w-full px-4 py-2 text-left text-white hover:bg-white/10 transition-colors"

--- a/src/components/SearchBar.tsx
+++ b/src/components/SearchBar.tsx
@@ -10,7 +10,7 @@ interface SearchBarProps {
 export function SearchBar({ className }: SearchBarProps) {
   const [query, setQuery] = useState('');
   const users = useUserStore((state) => state.users);
-  const setProfileUserId = useModalStore((state) => state.setProfileUserId);
+  const openProfileModal = useModalStore((state) => state.openProfileModal);
 
   const filteredUsers = users.filter((user) =>
     user.name.toLowerCase().includes(query.toLowerCase())
@@ -36,7 +36,7 @@ export function SearchBar({ className }: SearchBarProps) {
               <button
                 key={user.id}
                 onClick={() => {
-                  setProfileUserId(user.id);
+                  openProfileModal(user.id);
                   setQuery('');
                 }}
                 className="w-full px-4 py-2 flex items-center space-x-3 hover:bg-white/10 transition-colors"

--- a/src/components/UserNodes.tsx
+++ b/src/components/UserNodes.tsx
@@ -9,7 +9,7 @@ import * as THREE from 'three';
 export function UserNodes() {
   const users = useUserStore((state) => state.users);
   const currentUser = useAuthStore((state) => state.user);
-  const setProfileUserId = useModalStore((state) => state.setProfileUserId);
+  const openProfileModal = useModalStore((state) => state.openProfileModal);
   const groupRef = useRef<THREE.Group>(null);
 
   useFrame(() => {
@@ -45,7 +45,7 @@ export function UserNodes() {
         return (
           <group key={user.id} position={[x, y, z]}>
             <mesh
-              onClick={() => setProfileUserId(user.id)}
+              onClick={() => openProfileModal(user.id)}
               onPointerOver={(e) => {
                 e.stopPropagation();
                 document.body.style.cursor = 'pointer';

--- a/src/components/interface/ControlPanel.tsx
+++ b/src/components/interface/ControlPanel.tsx
@@ -11,7 +11,7 @@ export function ControlPanel() {
   const onlineUsers = users.filter((user) => user.online);
   const offlineUsers = users.filter((user) => !user.online);
   const setActiveChat = useChatStore((state) => state.setActiveChat);
-  const setProfileUserId = useModalStore((state) => state.setProfileUserId);
+  const openProfileModal = useModalStore((state) => state.openProfileModal);
 
   const otherUsers = users.filter((user) => user.id !== currentUser?.id);
 
@@ -87,7 +87,7 @@ export function ControlPanel() {
             <p className="font-mono text-sm text-white">{currentUser?.id ?? 'N/A'}</p>
           </div>
           <button
-            onClick={() => currentUser && setProfileUserId(currentUser.id)}
+            onClick={() => currentUser && openProfileModal(currentUser.id)}
             className="rounded-lg border border-white/10 bg-white/10 px-3 py-2 text-xs uppercase tracking-[0.2em] text-white/70 transition hover:bg-white/20"
           >
             Open dossier
@@ -127,7 +127,7 @@ export function ControlPanel() {
                 </div>
                 <div className="flex items-center gap-2">
                   <button
-                    onClick={() => setProfileUserId(user.id)}
+                    onClick={() => openProfileModal(user.id)}
                     className="rounded-lg border border-white/10 bg-white/10 px-3 py-2 text-xs uppercase tracking-[0.2em] text-white/60 transition hover:bg-white/20"
                   >
                     Profile

--- a/src/store/modalStore.ts
+++ b/src/store/modalStore.ts
@@ -1,11 +1,30 @@
 import { create } from 'zustand';
 
+type ProfileModalMode = 'view' | 'edit';
+
+interface ProfileModalState {
+  userId: string;
+  mode: ProfileModalMode;
+}
+
 interface ModalState {
-  profileUserId: string | null;
-  setProfileUserId: (userId: string | null) => void;
+  profileModal: ProfileModalState | null;
+  openProfileModal: (userId: string, mode?: ProfileModalMode) => void;
+  closeProfileModal: () => void;
+  setProfileModalMode: (mode: ProfileModalMode) => void;
 }
 
 export const useModalStore = create<ModalState>((set) => ({
-  profileUserId: null,
-  setProfileUserId: (userId) => set({ profileUserId: userId }),
+  profileModal: null,
+  openProfileModal: (userId, mode = 'view') =>
+    set({ profileModal: { userId, mode } }),
+  closeProfileModal: () => set({ profileModal: null }),
+  setProfileModalMode: (mode) =>
+    set((state) =>
+      state.profileModal
+        ? { profileModal: { ...state.profileModal, mode } }
+        : state
+    ),
 }));
+
+export type { ProfileModalMode, ProfileModalState };


### PR DESCRIPTION
## Summary
- track profile modal state and mode in the modal store so UI entry points can request view or edit behaviour
- update the profile modal and all launch points to respect the requested mode and expose cancel/save flows that keep labels accurate

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e1dc845e5c8323885b0013b9540604