### PR TITLE
Add fullscreen scene overlay toggle

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -11,6 +11,8 @@ import { HeaderBar } from './components/interface/HeaderBar';
 import { ControlPanel } from './components/interface/ControlPanel';
 import { BroadcastPanel } from './components/interface/BroadcastPanel';
 import { FieldNotesPanel } from './components/interface/FieldNotesPanel';
+import { useInterfaceStore } from './store/interfaceStore';
+import { Scene } from './components/Scene';
 
 export function App() {
   const isAuthenticated = useAuthStore((state) => state.isAuthenticated);
@@ -19,6 +21,8 @@ export function App() {
   const activeChat = useChatStore((state) => state.activeChat);
   const setActiveChat = useChatStore((state) => state.setActiveChat);
   const currentTheme = useThemeStore((state) => state.currentTheme);
+  const isSphereExpanded = useInterfaceStore((state) => state.isSphereExpanded);
+  const setSphereExpanded = useInterfaceStore((state) => state.setSphereExpanded);
 
   useEffect(() => {
     if (isAuthenticated) {
@@ -46,6 +50,27 @@ export function App() {
       <div className="pointer-events-none absolute -top-32 left-1/2 h-96 w-96 -translate-x-1/2 rounded-full bg-cyan-500/20 blur-3xl" />
       <div className="pointer-events-none absolute bottom-[-20%] right-[-10%] h-[32rem] w-[32rem] rounded-full bg-purple-500/20 blur-3xl" />
       <div className="pointer-events-none absolute top-1/2 left-[-15%] h-[24rem] w-[24rem] -translate-y-1/2 rounded-full bg-emerald-500/20 blur-3xl" />
+
+      {isSphereExpanded && (
+        <div className="fixed inset-0 z-50 flex items-center justify-center bg-slate-950/80 backdrop-blur-xl">
+          <div className="absolute inset-0" aria-hidden="true" onClick={() => setSphereExpanded(false)} />
+          <div className="relative z-10 flex h-full w-full max-w-6xl flex-col gap-4 p-6 sm:p-10">
+            <div className="flex items-center justify-end">
+              <button
+                type="button"
+                onClick={() => setSphereExpanded(false)}
+                className="rounded-full border border-white/20 bg-slate-900/80 px-4 py-2 text-xs uppercase tracking-[0.2em] text-white/70 transition hover:bg-slate-900"
+              >
+                Close
+              </button>
+            </div>
+            <div className="relative flex-1 overflow-hidden rounded-3xl border border-white/10 bg-slate-950/80 shadow-[0_40px_120px_-40px_rgba(15,23,42,0.9)]">
+              <Scene variant="fullscreen" className="h-full w-full" />
+              <div className="pointer-events-none absolute inset-0 rounded-3xl border border-white/10" />
+            </div>
+          </div>
+        </div>
+      )}
 
       {isAuthenticated ? (
         <div className="relative z-10 mx-auto flex min-h-screen max-w-7xl flex-col gap-8 px-4 py-6 sm:px-6 lg:px-10">

--- a/src/components/interface/ControlPanel.tsx
+++ b/src/components/interface/ControlPanel.tsx
@@ -3,6 +3,7 @@ import { useAuthStore } from '../../store/authStore';
 import { useUserStore } from '../../store/userStore';
 import { useChatStore } from '../../store/chatStore';
 import { useModalStore } from '../../store/modalStore';
+import { useInterfaceStore } from '../../store/interfaceStore';
 import { Activity, ShieldCheck, SignalHigh, Waves } from 'lucide-react';
 
 export function ControlPanel() {
@@ -12,6 +13,8 @@ export function ControlPanel() {
   const offlineUsers = users.filter((user) => !user.online);
   const setActiveChat = useChatStore((state) => state.setActiveChat);
   const setProfileUserId = useModalStore((state) => state.setProfileUserId);
+  const isSphereExpanded = useInterfaceStore((state) => state.isSphereExpanded);
+  const toggleSphereExpanded = useInterfaceStore((state) => state.toggleSphereExpanded);
 
   const otherUsers = users.filter((user) => user.id !== currentUser?.id);
 
@@ -37,10 +40,21 @@ export function ControlPanel() {
             </div>
           </div>
 
-          <div className="relative h-64 overflow-hidden rounded-2xl border border-white/10 bg-slate-950/60">
+          <button
+            type="button"
+            onClick={toggleSphereExpanded}
+            aria-expanded={isSphereExpanded}
+            className="group relative block h-64 w-full overflow-hidden rounded-2xl border border-white/10 bg-slate-950/60 text-left transition focus:outline-none focus-visible:ring-2 focus-visible:ring-cyan-400/80 focus-visible:ring-offset-2 focus-visible:ring-offset-slate-950"
+          >
             <Scene variant="embedded" />
             <div className="pointer-events-none absolute inset-0 rounded-2xl border border-white/5" />
-          </div>
+            <span className="pointer-events-none absolute bottom-4 right-4 rounded-full border border-white/10 bg-slate-950/70 px-3 py-1 text-xs uppercase tracking-[0.3em] text-white/60 opacity-0 transition group-hover:opacity-100">
+              Expand
+            </span>
+            <span className="sr-only">
+              {isSphereExpanded ? 'Collapse network sphere view' : 'Expand network sphere view'}
+            </span>
+          </button>
 
           <div className="grid grid-cols-3 gap-4 text-sm">
             <div className="rounded-2xl border border-white/10 bg-white/5 p-3">

--- a/src/store/interfaceStore.ts
+++ b/src/store/interfaceStore.ts
@@ -1,0 +1,14 @@
+import { create } from 'zustand';
+
+interface InterfaceState {
+  isSphereExpanded: boolean;
+  setSphereExpanded: (expanded: boolean) => void;
+  toggleSphereExpanded: () => void;
+}
+
+export const useInterfaceStore = create<InterfaceState>((set) => ({
+  isSphereExpanded: false,
+  setSphereExpanded: (expanded) => set({ isSphereExpanded: expanded }),
+  toggleSphereExpanded: () =>
+    set((state) => ({ isSphereExpanded: !state.isSphereExpanded })),
+}));


### PR DESCRIPTION
## Summary
- add a shared interface store to track the control panel sphere expansion state
- make the embedded scene focusable/clickable and toggle the fullscreen view
- render a fullscreen Scene overlay with close controls at the app root

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e1e08773dc832381398207a56de47d