### PR TITLE
Seed first-run demo operators and onboarding improvements

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -43,6 +43,9 @@ export function App() {
 
   return (
     <div className={`relative min-h-screen w-full overflow-hidden text-white ${getBackgroundClass()} transition-colors duration-1000`}>
+      <div className="pointer-events-none absolute inset-0 bg-[radial-gradient(circle_at_top,_rgba(59,130,246,0.18),_transparent_55%),radial-gradient(circle_at_bottom,_rgba(236,72,153,0.12),_transparent_60%)]" />
+      <div className="pointer-events-none absolute inset-0 bg-[linear-gradient(115deg,rgba(148,163,184,0.08)_0%,rgba(15,23,42,0.2)_45%,rgba(15,23,42,0.6)_55%,rgba(30,64,175,0.08)_100%)] mix-blend-screen" />
+      <div className="pointer-events-none absolute inset-0 bg-[linear-gradient(rgba(148,163,184,0.08)_1px,transparent_1px),linear-gradient(90deg,rgba(148,163,184,0.08)_1px,transparent_1px)] bg-[size:120px_120px] opacity-20" />
       <div className="pointer-events-none absolute -top-32 left-1/2 h-96 w-96 -translate-x-1/2 rounded-full bg-cyan-500/20 blur-3xl" />
       <div className="pointer-events-none absolute bottom-[-20%] right-[-10%] h-[32rem] w-[32rem] rounded-full bg-purple-500/20 blur-3xl" />
       <div className="pointer-events-none absolute top-1/2 left-[-15%] h-[24rem] w-[24rem] -translate-y-1/2 rounded-full bg-emerald-500/20 blur-3xl" />

--- a/src/components/auth/LoginForm.tsx
+++ b/src/components/auth/LoginForm.tsx
@@ -1,5 +1,5 @@
 import { useState } from 'react';
-import { useAuthStore } from '../../store/authStore';
+import { useAuthStore, DEFAULT_OPERATORS } from '../../store/authStore';
 import { LogIn } from 'lucide-react';
 
 export function LoginForm({ onToggle }: { onToggle: () => void }) {
@@ -60,6 +60,21 @@ export function LoginForm({ onToggle }: { onToggle: () => void }) {
           Sign In
         </button>
       </form>
+      <div className="mt-8 space-y-3 rounded-lg border border-white/10 bg-white/5 p-4 text-sm text-white/70">
+        <p className="text-xs uppercase tracking-[0.3em] text-white/50">Demo Access</p>
+        <p>
+          Sign in with one of the prelinked operators below or create your own account to explore the console.
+        </p>
+        <ul className="space-y-2 font-mono text-xs">
+          {DEFAULT_OPERATORS.map((operator) => (
+            <li key={operator.id} className="flex flex-wrap items-center gap-2">
+              <span className="rounded px-2 py-1 bg-white/10 text-white">{operator.email}</span>
+              <span className="text-white/50">/</span>
+              <span className="rounded px-2 py-1 bg-white/5 text-white/80">{operator.password}</span>
+            </li>
+          ))}
+        </ul>
+      </div>
       <p className="mt-6 text-center text-white/60">
         Don't have an account?{' '}
         <button

--- a/src/components/auth/RegisterForm.tsx
+++ b/src/components/auth/RegisterForm.tsx
@@ -2,12 +2,16 @@ import { useState } from 'react';
 import { useAuthStore } from '../../store/authStore';
 import { UserPlus } from 'lucide-react';
 
+const generateColor = () => `#${Math.floor(Math.random() * 0xffffff)
+  .toString(16)
+  .padStart(6, '0')}`;
+
 export function RegisterForm({ onToggle }: { onToggle: () => void }) {
   const [email, setEmail] = useState('');
   const [password, setPassword] = useState('');
   const [confirmPassword, setConfirmPassword] = useState('');
   const [name, setName] = useState('');
-  const [color, setColor] = useState('#' + Math.floor(Math.random()*16777215).toString(16));
+  const [color, setColor] = useState<string>(generateColor);
   const [error, setError] = useState('');
   const register = useAuthStore((state) => state.register);
 

--- a/src/components/interface/BroadcastPanel.tsx
+++ b/src/components/interface/BroadcastPanel.tsx
@@ -3,6 +3,8 @@ import { Satellite, Waves, MessageSquare, Shield, PlugZap } from 'lucide-react';
 import { useChatStore } from '../../store/chatStore';
 import { useUserStore } from '../../store/userStore';
 import { useAuthStore } from '../../store/authStore';
+import { GlassCard } from './GlassCard';
+import { StatusBadge } from './StatusBadge';
 
 export function BroadcastPanel() {
   const { activeChat, setActiveChat, getMessagesForChat } = useChatStore();
@@ -26,20 +28,14 @@ export function BroadcastPanel() {
       : [];
 
   return (
-    <section className="flex h-full flex-col gap-6 rounded-3xl border border-white/10 bg-white/5 p-6 shadow-[0_30px_80px_-40px_rgba(15,23,42,0.9)]">
+    <section className="flex h-full flex-col gap-6">
       <div className="flex flex-wrap items-center gap-3 text-xs uppercase tracking-[0.3em] text-white/50">
-        <span className="rounded-full border border-emerald-400/40 bg-emerald-500/10 px-3 py-1 text-emerald-300">
-          Quantum Axis // Aligned
-        </span>
-        <span className="rounded-full border border-sky-400/40 bg-sky-500/10 px-3 py-1 text-sky-300">
-          Broadcast Mode
-        </span>
-        <span className="rounded-full border border-white/10 px-3 py-1 text-white/60">
-          Link Integrity 99%
-        </span>
+        <StatusBadge tone="emerald">Quantum Axis // Aligned</StatusBadge>
+        <StatusBadge tone="sky">Broadcast Mode</StatusBadge>
+        <StatusBadge tone="slate">Link Integrity 99%</StatusBadge>
       </div>
 
-      <div className="flex flex-col gap-6 rounded-3xl border border-white/10 bg-slate-950/60 p-6">
+      <GlassCard className="flex flex-col gap-6 p-6">
         <div className="flex items-start justify-between gap-4">
           <div>
             <h2 className="text-2xl font-semibold text-white">Encrypted Relay // Broadcast</h2>
@@ -47,10 +43,12 @@ export function BroadcastPanel() {
               Choose a channel to open a secure quantum link. All transmissions are end-to-end encrypted and logged to the vault for 72 hours.
             </p>
           </div>
-          <Satellite className="h-8 w-8 text-sky-300" />
+          <StatusBadge tone="sky" className="tracking-[0.25em]">
+            <span className="flex items-center gap-2"><Satellite className="h-4 w-4" /> Relay Active</span>
+          </StatusBadge>
         </div>
 
-        <div className="rounded-2xl border border-white/10 bg-white/5 p-6 text-center">
+        <GlassCard tone="subtle" className="p-6 text-center">
           {activeUser ? (
             <div className="space-y-2">
               <p className="text-sm uppercase tracking-[0.3em] text-white/50">Active transmission</p>
@@ -68,10 +66,10 @@ export function BroadcastPanel() {
               <p className="text-sm text-white/60">Awaiting link handshake...</p>
             </div>
           )}
-        </div>
+        </GlassCard>
 
         <div className="grid gap-4 md:grid-cols-2">
-          <div className="flex flex-col gap-3 rounded-2xl border border-white/10 bg-white/5 p-4">
+          <GlassCard tone="subtle" className="flex flex-col gap-3 p-4 text-left">
             <label className="text-xs uppercase tracking-[0.3em] text-white/50">
               Channel Selection
             </label>
@@ -92,9 +90,9 @@ export function BroadcastPanel() {
             <p className="text-xs text-white/50">
               Selecting a channel prepares a private, encrypted relay path.
             </p>
-          </div>
+          </GlassCard>
 
-          <div className="flex flex-col justify-between rounded-2xl border border-white/10 bg-white/5 p-4">
+          <GlassCard tone="subtle" className="flex flex-col justify-between p-4">
             <div className="flex items-center justify-between text-sm text-white/60">
               <span>Handshake Status</span>
               <Shield className={`h-5 w-5 ${activeUser ? 'text-emerald-300' : 'text-white/40'}`} />
@@ -126,12 +124,12 @@ export function BroadcastPanel() {
                 </button>
               )}
             </div>
-          </div>
+          </GlassCard>
         </div>
-      </div>
+      </GlassCard>
 
       <div className="grid gap-4 md:grid-cols-3">
-        <div className="rounded-2xl border border-white/10 bg-white/5 p-4">
+        <GlassCard tone="subtle" className="p-4">
           <div className="flex items-center justify-between text-sm text-white/60">
             <span>Relay Logs</span>
             <MessageSquare className="h-5 w-5 text-sky-300" />
@@ -139,8 +137,8 @@ export function BroadcastPanel() {
           <p className="mt-2 text-xs text-white/50">
             {transcript.length} encrypted packets stored in session buffer.
           </p>
-        </div>
-        <div className="rounded-2xl border border-white/10 bg-white/5 p-4">
+        </GlassCard>
+        <GlassCard tone="subtle" className="p-4">
           <div className="flex items-center justify-between text-sm text-white/60">
             <span>Synchronization</span>
             <Waves className="h-5 w-5 text-emerald-300" />
@@ -148,8 +146,8 @@ export function BroadcastPanel() {
           <p className="mt-2 text-xs text-white/50">
             {activeUser ? 'Live presence detected on linked node.' : 'No active link. Awaiting handshake.'}
           </p>
-        </div>
-        <div className="rounded-2xl border border-white/10 bg-white/5 p-4">
+        </GlassCard>
+        <GlassCard tone="subtle" className="p-4">
           <div className="flex items-center justify-between text-sm text-white/60">
             <span>Power State</span>
             <PlugZap className="h-5 w-5 text-fuchsia-300" />
@@ -157,7 +155,7 @@ export function BroadcastPanel() {
           <p className="mt-2 text-xs text-white/50">
             All relays operating at nominal capacity.
           </p>
-        </div>
+        </GlassCard>
       </div>
     </section>
   );

--- a/src/components/interface/ControlPanel.tsx
+++ b/src/components/interface/ControlPanel.tsx
@@ -4,6 +4,8 @@ import { useUserStore } from '../../store/userStore';
 import { useChatStore } from '../../store/chatStore';
 import { useModalStore } from '../../store/modalStore';
 import { Activity, ShieldCheck, SignalHigh, Waves } from 'lucide-react';
+import { GlassCard } from './GlassCard';
+import { StatusBadge } from './StatusBadge';
 
 export function ControlPanel() {
   const currentUser = useAuthStore((state) => state.user);
@@ -17,90 +19,83 @@ export function ControlPanel() {
 
   return (
     <aside className="space-y-6">
-      <section className="relative overflow-hidden rounded-3xl border border-white/10 bg-white/5 p-6 shadow-[0_20px_60px_-30px_rgba(15,23,42,0.8)]">
-        <div className="pointer-events-none absolute -top-32 -right-10 h-64 w-64 rounded-full bg-cyan-500/30 blur-3xl" />
-        <div className="pointer-events-none absolute -bottom-32 -left-20 h-64 w-64 rounded-full bg-indigo-500/20 blur-3xl" />
+      <GlassCard className="p-6">
+        <div className="pointer-events-none absolute -top-32 -right-20 h-64 w-64 rounded-full bg-cyan-500/25 blur-3xl -z-10" />
+        <div className="pointer-events-none absolute -bottom-40 -left-24 h-72 w-72 rounded-full bg-indigo-500/25 blur-3xl -z-10" />
 
-        <div className="relative flex flex-col gap-6">
-          <div className="flex items-center justify-between">
+        <div className="flex flex-col gap-6">
+          <div className="flex items-start justify-between gap-4">
             <div>
-              <p className="text-xs uppercase tracking-[0.3em] text-white/50">
-                Control Lattice
-              </p>
-              <h2 className="mt-1 text-xl font-semibold text-white">
-                Operator Atlas
-              </h2>
+              <p className="text-xs uppercase tracking-[0.3em] text-white/50">Control Lattice</p>
+              <h2 className="mt-1 text-xl font-semibold text-white">Operator Atlas</h2>
             </div>
-            <div className="flex flex-col items-end text-xs text-white/60">
-              <span>Core Sync</span>
-              <span className="text-emerald-300">Stable</span>
+            <div className="flex flex-col items-end gap-2 text-xs text-white/60">
+              <StatusBadge tone="emerald" className="tracking-[0.25em]">Core Sync Stable</StatusBadge>
+              <span className="font-mono text-sm text-emerald-200">Integrity 99.2%</span>
             </div>
           </div>
 
-          <div className="relative h-64 overflow-hidden rounded-2xl border border-white/10 bg-slate-950/60">
+          <div className="relative h-64 overflow-hidden rounded-2xl border border-white/10 bg-slate-950/70">
             <Scene variant="embedded" />
-            <div className="pointer-events-none absolute inset-0 rounded-2xl border border-white/5" />
+            <div className="pointer-events-none absolute inset-0 rounded-2xl border border-white/10" />
           </div>
 
           <div className="grid grid-cols-3 gap-4 text-sm">
-            <div className="rounded-2xl border border-white/10 bg-white/5 p-3">
+            <div className="rounded-2xl border border-white/10 bg-slate-950/60 p-4">
               <div className="flex items-center justify-between text-white/60">
                 <span>Active Nodes</span>
                 <Activity className="h-4 w-4 text-emerald-300" />
               </div>
-              <p className="mt-2 text-2xl font-semibold text-white">{onlineUsers.length}</p>
+              <p className="mt-3 text-2xl font-semibold text-white">{onlineUsers.length}</p>
             </div>
-            <div className="rounded-2xl border border-white/10 bg-white/5 p-3">
+            <div className="rounded-2xl border border-white/10 bg-slate-950/60 p-4">
               <div className="flex items-center justify-between text-white/60">
                 <span>Standby</span>
                 <ShieldCheck className="h-4 w-4 text-sky-300" />
               </div>
-              <p className="mt-2 text-2xl font-semibold text-white">{offlineUsers.length}</p>
+              <p className="mt-3 text-2xl font-semibold text-white">{offlineUsers.length}</p>
             </div>
-            <div className="rounded-2xl border border-white/10 bg-white/5 p-3">
+            <div className="rounded-2xl border border-white/10 bg-slate-950/60 p-4">
               <div className="flex items-center justify-between text-white/60">
                 <span>Signal Integrity</span>
                 <SignalHigh className="h-4 w-4 text-fuchsia-300" />
               </div>
-              <p className="mt-2 text-2xl font-semibold text-emerald-300">99.2%</p>
+              <p className="mt-3 text-2xl font-semibold text-emerald-300">99.2%</p>
             </div>
           </div>
         </div>
-      </section>
+      </GlassCard>
 
-      <section className="rounded-3xl border border-white/10 bg-white/5 p-6 shadow-[0_20px_60px_-30px_rgba(15,23,42,0.8)]">
+      <GlassCard className="p-6">
         <div className="flex items-center justify-between">
           <div>
-            <p className="text-xs uppercase tracking-[0.3em] text-white/50">
-              Linked Operator
-            </p>
-            <h3 className="mt-1 text-lg font-semibold text-white">
-              {currentUser?.name ?? 'Unassigned'}</h3>
+            <p className="text-xs uppercase tracking-[0.3em] text-white/50">Linked Operator</p>
+            <h3 className="mt-1 text-lg font-semibold text-white">{currentUser?.name ?? 'Unassigned'}
+            </h3>
           </div>
-          <div className="rounded-full border border-white/10 bg-white/5 px-3 py-1 text-xs text-white/60">
-            {currentUser ? 'Ghost Operator' : 'Awaiting link'}
-          </div>
+          <StatusBadge tone={currentUser ? 'emerald' : 'slate'} className="tracking-[0.25em]">
+            {currentUser ? 'Ghost Operator' : 'Awaiting Link'}
+          </StatusBadge>
         </div>
-        <div className="mt-4 flex items-center justify-between rounded-2xl border border-white/10 bg-white/5 p-4">
+        <div className="mt-5 flex items-center justify-between rounded-2xl border border-white/10 bg-slate-950/60 p-4">
           <div>
             <p className="text-xs text-white/40">Node signature</p>
-            <p className="font-mono text-sm text-white">{currentUser?.id ?? 'N/A'}</p>
+            <p className="font-mono text-sm text-white">{currentUser?.id ?? 'N/A'}
+            </p>
           </div>
           <button
             onClick={() => currentUser && setProfileUserId(currentUser.id)}
-            className="rounded-lg border border-white/10 bg-white/10 px-3 py-2 text-xs uppercase tracking-[0.2em] text-white/70 transition hover:bg-white/20"
+            className="rounded-lg border border-white/10 bg-white/10 px-4 py-2 text-xs uppercase tracking-[0.2em] text-white/60 transition hover:bg-white/15"
           >
             Open dossier
           </button>
         </div>
-      </section>
+      </GlassCard>
 
-      <section className="rounded-3xl border border-white/10 bg-white/5 p-6 shadow-[0_20px_60px_-30px_rgba(15,23,42,0.8)]">
+      <GlassCard className="p-6">
         <div className="flex items-center justify-between">
           <div>
-            <p className="text-xs uppercase tracking-[0.3em] text-white/50">
-              Operator Matrix
-            </p>
+            <p className="text-xs uppercase tracking-[0.3em] text-white/50">Operator Matrix</p>
             <h3 className="mt-1 text-lg font-semibold text-white">Linked Channels</h3>
           </div>
           <Waves className="h-5 w-5 text-sky-300" />
@@ -111,7 +106,7 @@ export function ControlPanel() {
             otherUsers.map((user) => (
               <div
                 key={user.id}
-                className="flex items-center justify-between rounded-2xl border border-white/10 bg-white/5 p-3"
+                className="flex items-center justify-between rounded-2xl border border-white/10 bg-slate-950/60 p-3"
               >
                 <div className="flex items-center gap-3">
                   <div
@@ -128,7 +123,7 @@ export function ControlPanel() {
                 <div className="flex items-center gap-2">
                   <button
                     onClick={() => setProfileUserId(user.id)}
-                    className="rounded-lg border border-white/10 bg-white/10 px-3 py-2 text-xs uppercase tracking-[0.2em] text-white/60 transition hover:bg-white/20"
+                    className="rounded-lg border border-white/10 bg-white/10 px-3 py-2 text-xs uppercase tracking-[0.2em] text-white/60 transition hover:bg-white/15"
                   >
                     Profile
                   </button>
@@ -142,12 +137,13 @@ export function ControlPanel() {
               </div>
             ))
           ) : (
-            <div className="rounded-2xl border border-white/10 bg-white/5 p-6 text-center text-sm text-white/50">
+            <div className="rounded-2xl border border-white/10 bg-slate-950/60 p-6 text-center text-sm text-white/50">
               No auxiliary operators registered.
             </div>
           )}
         </div>
-      </section>
+      </GlassCard>
+
     </aside>
   );
 }

--- a/src/components/interface/FieldNotesPanel.tsx
+++ b/src/components/interface/FieldNotesPanel.tsx
@@ -1,5 +1,7 @@
 import { useState } from 'react';
 import { NotebookPen, Lock, Save, RefreshCcw, Tag } from 'lucide-react';
+import { GlassCard } from './GlassCard';
+import { StatusBadge } from './StatusBadge';
 
 interface SavedLog {
   id: string;
@@ -55,20 +57,18 @@ export function FieldNotesPanel() {
 
   return (
     <aside className="space-y-6">
-      <section className="rounded-3xl border border-white/10 bg-white/5 p-6 shadow-[0_20px_60px_-30px_rgba(15,23,42,0.8)]">
+      <GlassCard className="p-6">
         <div className="flex items-center justify-between">
           <div>
-            <p className="text-xs uppercase tracking-[0.3em] text-white/50">
-              Field Notes
-            </p>
-            <h3 className="mt-1 text-lg font-semibold text-white">
-              Tactical Annotations
-            </h3>
+            <p className="text-xs uppercase tracking-[0.3em] text-white/50">Field Notes</p>
+            <h3 className="mt-1 text-lg font-semibold text-white">Tactical Annotations</h3>
           </div>
-          <Lock className="h-5 w-5 text-emerald-300" />
+          <StatusBadge tone="emerald" className="tracking-[0.25em]">
+            <span className="flex items-center gap-2"><Lock className="h-4 w-4" /> Secure</span>
+          </StatusBadge>
         </div>
 
-        <div className="mt-5 rounded-2xl border border-white/10 bg-slate-950/60 p-4">
+        <GlassCard tone="subtle" className="mt-5 p-4">
           <div className="mb-3 flex items-center justify-between text-xs uppercase tracking-[0.3em] text-white/50">
             <span>Secure Notepad</span>
             <NotebookPen className="h-4 w-4 text-sky-300" />
@@ -113,10 +113,10 @@ export function FieldNotesPanel() {
               </button>
             </div>
           </div>
-        </div>
-      </section>
+        </GlassCard>
+      </GlassCard>
 
-      <section className="rounded-3xl border border-white/10 bg-white/5 p-6 shadow-[0_20px_60px_-30px_rgba(15,23,42,0.8)]">
+      <GlassCard className="p-6">
         <div className="flex items-center justify-between text-xs uppercase tracking-[0.3em] text-white/50">
           <span>Saved Logs</span>
           <RefreshCcw className="h-4 w-4 text-white/40" />
@@ -124,9 +124,10 @@ export function FieldNotesPanel() {
         <div className="mt-4 space-y-3">
           {savedLogs.length > 0 ? (
             savedLogs.map((log) => (
-              <div
+              <GlassCard
                 key={log.id}
-                className="rounded-2xl border border-white/10 bg-white/5 p-4"
+                tone="subtle"
+                className="p-4"
               >
                 <div className="flex items-center justify-between text-xs uppercase tracking-[0.3em] text-white/50">
                   <span>{formatTime(log.timestamp)}</span>
@@ -143,15 +144,15 @@ export function FieldNotesPanel() {
                   </span>
                 </div>
                 <p className="mt-3 text-sm text-white/70">{log.content}</p>
-              </div>
+              </GlassCard>
             ))
           ) : (
-            <div className="rounded-2xl border border-white/10 bg-white/5 p-6 text-center text-sm text-white/50">
+            <GlassCard tone="subtle" className="p-6 text-center text-sm text-white/50">
               No saved logs yet.
-            </div>
+            </GlassCard>
           )}
         </div>
-      </section>
+      </GlassCard>
     </aside>
   );
 }

--- a/src/components/interface/GlassCard.tsx
+++ b/src/components/interface/GlassCard.tsx
@@ -1,0 +1,41 @@
+import { ReactNode } from 'react';
+
+interface GlassCardProps {
+  children: ReactNode;
+  className?: string;
+  tone?: 'default' | 'subtle';
+}
+
+const toneConfig: Record<NonNullable<GlassCardProps['tone']>, {
+  wrapper: string;
+  baseOverlay: string;
+  insetOverlay: string;
+  gradient: string;
+}> = {
+  default: {
+    wrapper: 'bg-white/5',
+    baseOverlay: 'bg-slate-950/50',
+    insetOverlay: 'bg-slate-950/40',
+    gradient: 'from-white/10',
+  },
+  subtle: {
+    wrapper: 'bg-white/10',
+    baseOverlay: 'bg-slate-950/40',
+    insetOverlay: 'bg-slate-950/25',
+    gradient: 'from-white/5',
+  },
+};
+
+export function GlassCard({ children, className = '', tone = 'default' }: GlassCardProps) {
+  const toneStyles = toneConfig[tone];
+  return (
+    <div
+      className={`relative overflow-hidden rounded-3xl border border-white/10 shadow-[0_24px_60px_-30px_rgba(15,23,42,0.9)] ${toneStyles.wrapper} ${className}`}
+    >
+      <div className={`absolute inset-0 ${toneStyles.baseOverlay}`} aria-hidden />
+      <div className={`absolute inset-px rounded-[26px] border border-white/5 ${toneStyles.insetOverlay}`} aria-hidden />
+      <div className={`pointer-events-none absolute inset-0 rounded-3xl bg-gradient-to-br ${toneStyles.gradient} via-transparent to-transparent`} />
+      <div className="relative z-10">{children}</div>
+    </div>
+  );
+}

--- a/src/components/interface/StatusBadge.tsx
+++ b/src/components/interface/StatusBadge.tsx
@@ -1,0 +1,30 @@
+import { ReactNode } from 'react';
+
+const badgeStyles = {
+  emerald: 'border-emerald-400/50 bg-emerald-500/10 text-emerald-200 shadow-[0_0_20px_rgba(16,185,129,0.25)]',
+  sky: 'border-sky-400/50 bg-sky-500/10 text-sky-200 shadow-[0_0_20px_rgba(56,189,248,0.25)]',
+  fuchsia: 'border-fuchsia-400/50 bg-fuchsia-500/10 text-fuchsia-200 shadow-[0_0_20px_rgba(232,121,249,0.25)]',
+  slate: 'border-white/10 bg-white/5 text-white/70 shadow-[0_0_18px_rgba(148,163,184,0.15)]',
+};
+
+type StatusBadgeTone = keyof typeof badgeStyles;
+
+interface StatusBadgeProps {
+  tone?: StatusBadgeTone;
+  icon?: ReactNode;
+  children: ReactNode;
+  className?: string;
+}
+
+export function StatusBadge({ tone = 'slate', icon, children, className = '' }: StatusBadgeProps) {
+  return (
+    <span
+      className={`inline-flex items-center gap-2 rounded-full border px-4 py-1 text-xs uppercase tracking-[0.3em] backdrop-blur-lg ${
+        badgeStyles[tone]
+      } ${className}`}
+    >
+      {icon && <span className="text-base">{icon}</span>}
+      {children}
+    </span>
+  );
+}

--- a/src/store/authStore.ts
+++ b/src/store/authStore.ts
@@ -2,7 +2,7 @@ import { create } from 'zustand';
 import { persist } from 'zustand/middleware';
 import { useUserStore } from './userStore';
 
-interface User {
+export interface User {
   id: string;
   name: string;
   color: string;
@@ -11,6 +11,38 @@ interface User {
   profilePicture?: string;
   bio?: string;
 }
+
+export const DEFAULT_OPERATORS: User[] = [
+  {
+    id: 'user_aurora',
+    name: 'Aurora Chen',
+    email: 'aurora@enclypse.io',
+    password: 'quantum-link',
+    color: '#6366F1',
+    bio: 'Lead signal architect monitoring the deep field relays.',
+  },
+  {
+    id: 'user_orion',
+    name: 'Orion Vega',
+    email: 'orion@enclypse.io',
+    password: 'pulse-array',
+    color: '#22D3EE',
+    bio: 'Operations chief coordinating away team uplinks.',
+  },
+  {
+    id: 'user_lyra',
+    name: 'Lyra Das',
+    email: 'lyra@enclypse.io',
+    password: 'nebula-core',
+    color: '#F97316',
+    bio: 'Intelligence analyst cataloging recovered transmissions.',
+  },
+];
+
+const generateRandomColor = () =>
+  `#${Math.floor(Math.random() * 0xffffff)
+    .toString(16)
+    .padStart(6, '0')}`;
 
 interface AuthState {
   user: User | null;
@@ -27,7 +59,7 @@ export const useAuthStore = create<AuthState>()(
     (set, get) => ({
       user: null,
       isAuthenticated: false,
-      registeredUsers: [],
+      registeredUsers: DEFAULT_OPERATORS,
 
       register: (userData) => {
         const { registeredUsers } = get();
@@ -42,7 +74,7 @@ export const useAuthStore = create<AuthState>()(
           name: userData.name || userData.email.split('@')[0],
           email: userData.email,
           password: userData.password,
-          color: userData.color || '#' + Math.floor(Math.random()*16777215).toString(16),
+          color: userData.color || generateRandomColor(),
         };
 
         set(state => ({

--- a/src/store/mockData.ts
+++ b/src/store/mockData.ts
@@ -1,5 +1,6 @@
 import { useUserStore } from './userStore';
-import { useAuthStore } from './authStore';
+import { useAuthStore, DEFAULT_OPERATORS } from './authStore';
+import { useChatStore } from './chatStore';
 
 // Helper function to get random position on a sphere
 function getRandomSpherePosition(radius: number = 3): [number, number, number] {
@@ -13,19 +14,31 @@ function getRandomSpherePosition(radius: number = 3): [number, number, number] {
 }
 
 export function initializeMockData() {
-  const addUser = useUserStore.getState().addUser;
-  const setOnlineStatus = useUserStore.getState().setOnlineStatus;
-  const updateUserPosition = useUserStore.getState().updateUserPosition;
+  const userStore = useUserStore.getState();
+  const chatStore = useChatStore.getState();
+  const addUser = userStore.addUser;
+  const setOnlineStatus = userStore.setOnlineStatus;
+  const updateUserPosition = userStore.updateUserPosition;
   const currentUser = useAuthStore.getState().user;
   const registeredUsers = useAuthStore.getState().registeredUsers;
+  const knownUserIds = new Set(userStore.users.map((user) => user.id));
+
+  const activeOperatorIds = new Set(['user_aurora', 'user_orion']);
+  const welcomeOperatorId = 'user_aurora';
+  const welcomeOperator =
+    registeredUsers.find((user) => user.id === welcomeOperatorId) ??
+    DEFAULT_OPERATORS.find((user) => user.id === welcomeOperatorId);
 
   // Add current user to the sphere
   if (currentUser) {
-    addUser({
-      ...currentUser,
-      position: getRandomSpherePosition(),
-      online: true,
-    });
+    if (!knownUserIds.has(currentUser.id)) {
+      addUser({
+        ...currentUser,
+        position: getRandomSpherePosition(),
+        online: true,
+      });
+      knownUserIds.add(currentUser.id);
+    }
     setOnlineStatus(currentUser.id, true);
     updateUserPosition(currentUser.id, getRandomSpherePosition());
   }
@@ -33,12 +46,37 @@ export function initializeMockData() {
   // Add all registered users except current user
   registeredUsers
     .filter(user => user.id !== currentUser?.id)
-    .forEach(user => {
-      addUser({
-        ...user,
-        position: getRandomSpherePosition(),
-        online: false,
-      });
+    .forEach((user) => {
+      if (!knownUserIds.has(user.id)) {
+        addUser({
+          ...user,
+          position: getRandomSpherePosition(),
+          online: false,
+        });
+        knownUserIds.add(user.id);
+      }
+
       updateUserPosition(user.id, getRandomSpherePosition());
+      if (activeOperatorIds.has(user.id)) {
+        setOnlineStatus(user.id, true);
+      } else {
+        setOnlineStatus(user.id, false);
+      }
     });
+
+  if (currentUser && welcomeOperator) {
+    const hasWelcomeMessage = chatStore.messages.some(
+      (message) =>
+        message.fromUserId === welcomeOperatorId &&
+        message.toUserId === currentUser.id
+    );
+
+    if (!hasWelcomeMessage) {
+      chatStore.sendMessage(
+        welcomeOperatorId,
+        currentUser.id,
+        'Welcome to Enclypse Command. I have you synced on the lattice—let me know when you are ready to go live.'
+      );
+    }
+  }
 }


### PR DESCRIPTION
## Summary
- add default Enclypse operators and surface their demo credentials directly in the login modal for quick access
- harden registration color generation and seed the mock data store with curated operator presence and welcome messaging
- ensure first login initializes shared state without duplication so new users see an active network immediately

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e2aa277c6c8323995b9f1340c9f9d6