### PR TITLE
Add permission-aware test coverage for layered content

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,10 @@
     "dev": "vite",
     "build": "vite build",
     "lint": "eslint .",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "test": "vitest",
+    "test:watch": "vitest watch",
+    "test:coverage": "vitest run --coverage"
   },
   "dependencies": {
     "@react-three/drei": "^9.99.0",
@@ -20,19 +23,24 @@
   },
   "devDependencies": {
     "@eslint/js": "^9.9.1",
+    "@testing-library/react": "^16.0.1",
+    "@testing-library/user-event": "^14.6.1",
     "@types/react": "^18.3.5",
     "@types/react-dom": "^18.3.0",
     "@types/three": "^0.161.2",
     "@vitejs/plugin-react": "^4.3.1",
+    "@vitest/coverage-v8": "^2.1.4",
     "autoprefixer": "^10.4.18",
     "eslint": "^9.9.1",
     "eslint-plugin-react-hooks": "^5.1.0-rc.0",
     "eslint-plugin-react-refresh": "^0.4.11",
     "globals": "^15.9.0",
+    "jsdom": "^25.0.1",
     "postcss": "^8.4.35",
     "tailwindcss": "^3.4.1",
     "typescript": "^5.5.3",
     "typescript-eslint": "^8.3.0",
-    "vite": "^5.4.2"
+    "vite": "^5.4.2",
+    "vitest": "^2.1.4"
   }
 }

--- a/src/__tests__/app.integration.test.tsx
+++ b/src/__tests__/app.integration.test.tsx
@@ -1,0 +1,74 @@
+import { describe, it, expect } from 'vitest';
+import { act } from 'react-dom/test-utils';
+import { render, screen, waitFor } from '../test-utils/testing-library-react';
+import userEvent from '../test-utils/user-event';
+import { App } from '../App';
+import { useLayerStore } from '../store/layerStore';
+
+async function completeOnboarding() {
+  render(<App />);
+  await userEvent.click(screen.getByRole('button', { name: /sign up/i }));
+  await userEvent.type(screen.getByPlaceholderText('Email'), 'tester@example.com');
+  await userEvent.type(
+    screen.getByPlaceholderText('Display Name (optional)'),
+    'Tester',
+  );
+  await userEvent.type(
+    screen.getByPlaceholderText('Password (min. 6 characters)'),
+    'strongpass',
+  );
+  await userEvent.type(
+    screen.getByPlaceholderText('Confirm Password'),
+    'strongpass',
+  );
+  await userEvent.click(screen.getByRole('button', { name: /sign up/i }));
+  await waitFor(() => expect(screen.getByText(/Operator Atlas/i)).toBeTruthy());
+}
+
+describe('App integration flows', () => {
+  it('completes onboarding and reveals console', async () => {
+    await completeOnboarding();
+    expect(screen.getByText(/Quantum Link Console/i)).toBeTruthy();
+    expect(screen.getByText(/Operator Atlas/i)).toBeTruthy();
+  });
+
+  it('enforces visibility toggles and propagates permission updates', async () => {
+    await completeOnboarding();
+
+    expect(screen.getByText(/Awaiting decoded intel/i)).toBeTruthy();
+    expect(screen.queryByText(/Authorize sync capsule/i)).toBeNull();
+
+    await userEvent.click(screen.getByTestId('layer-toggle-trusted'));
+    await waitFor(() => {
+      expect(screen.queryByText(/Awaiting decoded intel/i)).toBeNull();
+    });
+
+    await act(async () => {
+      useLayerStore.getState().setPermissionContext({ role: 'operator' });
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText(/Authorize sync capsule/i)).toBeTruthy();
+      expect(screen.getByText(/Awaiting decoded intel/i)).toBeTruthy();
+    });
+  });
+
+  it('handles restricted content lifecycle without leaking data', async () => {
+    await completeOnboarding();
+
+    const textarea = screen.getByPlaceholderText(/compose encrypted field note/i);
+    await userEvent.clear(textarea);
+    await userEvent.type(textarea, 'Quantum restricted log');
+    await userEvent.click(screen.getByRole('button', { name: /save log/i }));
+
+    expect(screen.queryByText(/Quantum restricted log/i)).toBeNull();
+
+    await act(async () => {
+      useLayerStore.getState().elevateRole('operator');
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText(/Quantum restricted log/i)).toBeTruthy();
+    });
+  });
+});

--- a/src/setupTests.ts
+++ b/src/setupTests.ts
@@ -1,0 +1,22 @@
+import { afterEach } from 'vitest';
+import { cleanup } from './test-utils/testing-library-react';
+import { resetLayerStore } from './store/layerStore';
+import { resetLayerContentStore } from './store/layerContentStore';
+import { useAuthStore } from './store/authStore';
+import { useUserStore } from './store/userStore';
+import { useChatStore } from './store/chatStore';
+import { useModalStore } from './store/modalStore';
+import { useThemeStore } from './store/themeStore';
+
+afterEach(() => {
+  cleanup();
+  localStorage.clear();
+  sessionStorage.clear?.();
+  resetLayerStore();
+  resetLayerContentStore();
+  useAuthStore.setState({ user: null, isAuthenticated: false, registeredUsers: [] });
+  useUserStore.setState({ users: [], onlineUsers: new Set<string>() });
+  useChatStore.setState({ activeChat: null, messages: [] });
+  useModalStore.setState({ profileUserId: null });
+  useThemeStore.setState({ currentTheme: 'classic' });
+});

--- a/src/store/layerContentStore.test.ts
+++ b/src/store/layerContentStore.test.ts
@@ -1,0 +1,56 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import {
+  useLayerContentStore,
+  resetLayerContentStore,
+  TAG_TO_LAYER,
+} from './layerContentStore';
+import { withRole, type PermissionContext } from '../utils/permissions';
+
+describe('layer content store', () => {
+  const baseContext: PermissionContext = { role: 'member' };
+
+  beforeEach(() => {
+    resetLayerContentStore();
+  });
+
+  it('creates new entries at the top of the feed', () => {
+    const before = useLayerContentStore.getState().entries.length;
+    const entry = useLayerContentStore
+      .getState()
+      .createEntry({
+        content: 'Test note',
+        layer: TAG_TO_LAYER.Harmony,
+        tag: 'Harmony',
+        ownerId: 'tester',
+      });
+    const state = useLayerContentStore.getState();
+    expect(state.entries.length).toBe(before + 1);
+    expect(state.entries[0].id).toBe(entry.id);
+  });
+
+  it('updates and deletes entries', () => {
+    const [first] = useLayerContentStore.getState().entries;
+    const updated = useLayerContentStore
+      .getState()
+      .updateEntry(first.id, { content: 'Updated content', tag: 'Beacon' });
+    expect(updated?.content).toBe('Updated content');
+    expect(updated?.tag).toBe('Beacon');
+
+    useLayerContentStore.getState().deleteEntry(first.id);
+    expect(useLayerContentStore.getState().entries.find((entry) => entry.id === first.id)).toBeUndefined();
+  });
+
+  it('filters visible entries by permission-aware layers', () => {
+    const items = useLayerContentStore
+      .getState()
+      .getVisibleEntries(['public', 'trusted', 'restricted'], baseContext);
+    const ids = items.map((item) => item.tag);
+    expect(ids).not.toContain('Priority');
+
+    const elevated = withRole(baseContext, 'operator');
+    const elevatedItems = useLayerContentStore
+      .getState()
+      .getVisibleEntries(['public', 'trusted', 'restricted'], elevated);
+    expect(elevatedItems.map((item) => item.tag)).toContain('Priority');
+  });
+});

--- a/src/store/layerContentStore.ts
+++ b/src/store/layerContentStore.ts
@@ -1,0 +1,111 @@
+import { create } from 'zustand';
+import type { Layer, PermissionContext } from '../utils/permissions';
+import { filterItemsByLayerAccess } from '../utils/permissions';
+
+export type LayerTag = 'Priority' | 'Beacon' | 'Harmony';
+
+export interface LayeredLog {
+  id: string;
+  layer: Layer;
+  tag: LayerTag;
+  content: string;
+  ownerId: string;
+  createdAt: number;
+  updatedAt: number;
+}
+
+export const TAG_TO_LAYER: Record<LayerTag, Layer> = {
+  Priority: 'restricted',
+  Beacon: 'trusted',
+  Harmony: 'public',
+};
+
+const DEFAULT_LOGS: LayeredLog[] = [
+  {
+    id: '1',
+    layer: TAG_TO_LAYER.Beacon,
+    tag: 'Beacon',
+    content: 'Awaiting decoded intel from Node Sigma. Maintain passive watch.',
+    ownerId: 'system',
+    createdAt: Date.now() - 1000 * 60 * 12,
+    updatedAt: Date.now() - 1000 * 60 * 12,
+  },
+  {
+    id: '2',
+    layer: TAG_TO_LAYER.Priority,
+    tag: 'Priority',
+    content: 'Authorize sync capsule for Ops team. Request new clearance tokens.',
+    ownerId: 'system',
+    createdAt: Date.now() - 1000 * 60 * 45,
+    updatedAt: Date.now() - 1000 * 60 * 45,
+  },
+];
+
+interface LayerContentState {
+  entries: LayeredLog[];
+  createEntry: (input: {
+    content: string;
+    layer: Layer;
+    tag: LayerTag;
+    ownerId: string;
+  }) => LayeredLog;
+  updateEntry: (
+    id: string,
+    updates: Partial<Pick<LayeredLog, 'content' | 'layer' | 'tag'>>,
+  ) => LayeredLog | null;
+  deleteEntry: (id: string) => void;
+  getEntriesByLayer: (layer: Layer) => LayeredLog[];
+  getVisibleEntries: (layers: Layer[], context: PermissionContext) => LayeredLog[];
+}
+
+function sortByTimestamp(entries: LayeredLog[]): LayeredLog[] {
+  return [...entries].sort((a, b) => b.createdAt - a.createdAt);
+}
+
+export const useLayerContentStore = create<LayerContentState>((set, get) => ({
+  entries: sortByTimestamp(DEFAULT_LOGS),
+  createEntry: (input) => {
+    const timestamp = Date.now();
+    const entry: LayeredLog = {
+      id: `log_${timestamp}_${Math.random().toString(36).slice(2, 8)}`,
+      content: input.content,
+      layer: input.layer,
+      tag: input.tag,
+      ownerId: input.ownerId,
+      createdAt: timestamp,
+      updatedAt: timestamp,
+    };
+    set((state) => ({ entries: sortByTimestamp([entry, ...state.entries]) }));
+    return entry;
+  },
+  updateEntry: (id, updates) => {
+    let updatedEntry: LayeredLog | null = null;
+    set((state) => ({
+      entries: sortByTimestamp(
+        state.entries.map((entry) => {
+          if (entry.id !== id) return entry;
+          updatedEntry = {
+            ...entry,
+            ...updates,
+            updatedAt: Date.now(),
+          };
+          return updatedEntry;
+        }),
+      ),
+    }));
+    return updatedEntry;
+  },
+  deleteEntry: (id) => {
+    set((state) => ({ entries: state.entries.filter((entry) => entry.id !== id) }));
+  },
+  getEntriesByLayer: (layer) => {
+    return get().entries.filter((entry) => entry.layer === layer);
+  },
+  getVisibleEntries: (layers, context) => {
+    return filterItemsByLayerAccess(get().entries, context, layers);
+  },
+}));
+
+export function resetLayerContentStore() {
+  useLayerContentStore.setState({ entries: sortByTimestamp(DEFAULT_LOGS) });
+}

--- a/src/store/layerStore.test.ts
+++ b/src/store/layerStore.test.ts
@@ -1,0 +1,42 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { useLayerStore, resetLayerStore } from './layerStore';
+import { withRole } from '../utils/permissions';
+
+describe('layer store', () => {
+  beforeEach(() => {
+    resetLayerStore();
+  });
+
+  it('toggles accessible layers on and off', () => {
+    const initial = useLayerStore.getState();
+    expect(initial.isLayerActive('public')).toBe(true);
+    useLayerStore.getState().toggleLayer('public');
+    expect(useLayerStore.getState().isLayerActive('public')).toBe(false);
+    useLayerStore.getState().toggleLayer('public');
+    expect(useLayerStore.getState().isLayerActive('public')).toBe(true);
+  });
+
+  it('prevents activating layers without permission', () => {
+    const state = useLayerStore.getState();
+    expect(state.isLayerAccessible('restricted')).toBe(false);
+    state.toggleLayer('restricted');
+    expect(useLayerStore.getState().isLayerActive('restricted')).toBe(false);
+  });
+
+  it('updates visible layers atomically when permissions change', () => {
+    const baseState = useLayerStore.getState();
+    expect(baseState.getVisibleLayers()).toEqual(['public', 'trusted']);
+    const elevatedContext = withRole(baseState.permissionContext, 'operator');
+    useLayerStore.getState().setPermissionContext(elevatedContext);
+    expect(useLayerStore.getState().getVisibleLayers()).toEqual([
+      'public',
+      'trusted',
+      'restricted',
+    ]);
+  });
+
+  it('accepts explicit elevation helper', () => {
+    useLayerStore.getState().elevateRole('operator');
+    expect(useLayerStore.getState().isLayerAccessible('restricted')).toBe(true);
+  });
+});

--- a/src/store/layerStore.ts
+++ b/src/store/layerStore.ts
@@ -1,0 +1,98 @@
+import { create } from 'zustand';
+import {
+  LAYERS,
+  type Layer,
+  type PermissionContext,
+  canAccessLayer,
+  getAccessibleLayers,
+  sortLayers,
+  withRole,
+} from '../utils/permissions';
+
+const DEFAULT_PERMISSION_CONTEXT: PermissionContext = { role: 'member' };
+
+interface LayerState {
+  availableLayers: Layer[];
+  activeLayers: Layer[];
+  permissionContext: PermissionContext;
+  toggleLayer: (layer: Layer) => void;
+  setActiveLayers: (layers: Layer[]) => void;
+  setPermissionContext: (context: PermissionContext) => void;
+  elevateRole: (role: PermissionContext['role']) => void;
+  isLayerActive: (layer: Layer) => boolean;
+  isLayerAccessible: (layer: Layer) => boolean;
+  getVisibleLayers: () => Layer[];
+}
+
+function computeDefaultLayers(context: PermissionContext): Layer[] {
+  return sortLayers(getAccessibleLayers(context));
+}
+
+function sanitizeLayers(layers: Layer[], context: PermissionContext): Layer[] {
+  const accessible = new Set(getAccessibleLayers(context));
+  const sanitized = layers.filter((layer) => accessible.has(layer));
+  return sortLayers(Array.from(new Set(sanitized)));
+}
+
+const initialState = {
+  availableLayers: LAYERS.map((metadata) => metadata.id),
+  activeLayers: computeDefaultLayers(DEFAULT_PERMISSION_CONTEXT),
+  permissionContext: { ...DEFAULT_PERMISSION_CONTEXT },
+};
+
+export const useLayerStore = create<LayerState>((set, get) => ({
+  ...initialState,
+  toggleLayer: (layer) => {
+    const state = get();
+    if (!state.availableLayers.includes(layer) || !canAccessLayer(state.permissionContext, layer)) {
+      return;
+    }
+    const isActive = state.activeLayers.includes(layer);
+    const nextActive = isActive
+      ? state.activeLayers.filter((existing) => existing !== layer)
+      : sortLayers([...state.activeLayers, layer]);
+    set({ activeLayers: nextActive });
+  },
+  setActiveLayers: (layers) => {
+    const state = get();
+    set({ activeLayers: sanitizeLayers(layers, state.permissionContext) });
+  },
+  setPermissionContext: (context) => {
+    const nextContext: PermissionContext = {
+      role: context.role,
+      overrides: context.overrides ? { ...context.overrides } : undefined,
+    };
+    set({
+      permissionContext: nextContext,
+      activeLayers: computeDefaultLayers(nextContext),
+    });
+  },
+  elevateRole: (role) => {
+    const nextContext = withRole(get().permissionContext, role);
+    set({
+      permissionContext: nextContext,
+      activeLayers: computeDefaultLayers(nextContext),
+    });
+  },
+  isLayerActive: (layer) => {
+    const state = get();
+    return state.activeLayers.includes(layer) && canAccessLayer(state.permissionContext, layer);
+  },
+  isLayerAccessible: (layer) => {
+    return canAccessLayer(get().permissionContext, layer);
+  },
+  getVisibleLayers: () => {
+    const state = get();
+    return sanitizeLayers(state.activeLayers, state.permissionContext);
+  },
+}));
+
+export function resetLayerStore() {
+  useLayerStore.setState({
+    availableLayers: LAYERS.map((metadata) => metadata.id),
+    activeLayers: computeDefaultLayers(DEFAULT_PERMISSION_CONTEXT),
+    permissionContext: { ...DEFAULT_PERMISSION_CONTEXT },
+  });
+}
+
+export { DEFAULT_PERMISSION_CONTEXT };

--- a/src/test-utils/testing-library-react.tsx
+++ b/src/test-utils/testing-library-react.tsx
@@ -1,0 +1,298 @@
+import type { ReactElement } from 'react';
+import React, { StrictMode } from 'react';
+import { act } from 'react-dom/test-utils';
+import { createRoot, Root } from 'react-dom/client';
+
+type TextMatch = string | RegExp;
+
+type QueryOptions = {
+  name?: TextMatch;
+  selector?: string;
+};
+
+type FindOptions = QueryOptions & {
+  timeout?: number;
+  interval?: number;
+};
+
+interface RenderResult {
+  container: HTMLElement;
+  unmount: () => void;
+  rerender: (ui: ReactElement) => void;
+}
+
+let currentRoot: Root | null = null;
+let currentContainer: HTMLElement | null = null;
+
+const DEFAULT_TIMEOUT = 2000;
+const DEFAULT_INTERVAL = 50;
+
+function matchesText(text: string | null | undefined, matcher: TextMatch): boolean {
+  if (text == null) return false;
+  if (typeof matcher === 'string') {
+    return text.toLowerCase().includes(matcher.toLowerCase());
+  }
+  return matcher.test(text);
+}
+
+function getNodeLabel(node: Element): string {
+  const ariaLabel = node.getAttribute('aria-label');
+  if (ariaLabel) return ariaLabel;
+  if (node instanceof HTMLInputElement || node instanceof HTMLTextAreaElement) {
+    if (node.placeholder) return node.placeholder;
+    if (node.value) return String(node.value);
+  }
+  return node.textContent ?? '';
+}
+
+function queryAllByText(container: Element, matcher: TextMatch): Element[] {
+  const nodes = Array.from(container.querySelectorAll('*'));
+  return nodes.filter((node) => matchesText(node.textContent, matcher));
+}
+
+function queryByText(container: Element, matcher: TextMatch): Element | null {
+  return queryAllByText(container, matcher)[0] ?? null;
+}
+
+function getByText(container: Element, matcher: TextMatch): Element {
+  const result = queryByText(container, matcher);
+  if (!result) {
+    throw new Error(`Unable to find element with text: ${matcher.toString()}`);
+  }
+  return result;
+}
+
+function queryAllByRole(container: Element, role: string, options: QueryOptions = {}): Element[] {
+  const normalizedRole = role.toLowerCase();
+  const candidates = Array.from(container.querySelectorAll(options.selector ?? '*'));
+  return candidates.filter((node) => {
+    const explicitRole = node.getAttribute('role');
+    const matchesRole = explicitRole
+      ? explicitRole.toLowerCase() === normalizedRole
+      : matchesImplicitRole(node, normalizedRole);
+    if (!matchesRole) {
+      return false;
+    }
+    if (options.name) {
+      return matchesText(getNodeLabel(node), options.name);
+    }
+    return true;
+  });
+}
+
+function matchesImplicitRole(node: Element, role: string): boolean {
+  const tag = node.tagName.toLowerCase();
+  switch (role) {
+    case 'button':
+      return tag === 'button' || (tag === 'input' && ['button', 'submit'].includes((node as HTMLInputElement).type));
+    case 'textbox':
+      return tag === 'textarea' || (tag === 'input' && !['button', 'submit', 'checkbox', 'radio'].includes((node as HTMLInputElement).type));
+    case 'combobox':
+      return tag === 'select';
+    case 'heading':
+      return /^h[1-6]$/.test(tag);
+    case 'link':
+      return tag === 'a';
+    default:
+      return false;
+  }
+}
+
+function queryByRole(container: Element, role: string, options: QueryOptions = {}): Element | null {
+  return queryAllByRole(container, role, options)[0] ?? null;
+}
+
+function getByRole(container: Element, role: string, options: QueryOptions = {}): Element {
+  const result = queryByRole(container, role, options);
+  if (!result) {
+    throw new Error(`Unable to find role "${role}"` + (options.name ? ` with name ${options.name}` : ''));
+  }
+  return result;
+}
+
+function queryByLabelText(container: Element, matcher: TextMatch): Element | null {
+  const labels = Array.from(container.querySelectorAll('label'));
+  for (const label of labels) {
+    if (!matchesText(label.textContent, matcher)) continue;
+    const htmlFor = label.getAttribute('for');
+    if (htmlFor) {
+      const control = container.querySelector(`#${CSS.escape(htmlFor)}`);
+      if (control instanceof HTMLElement) return control;
+    }
+    const control = label.querySelector('input,textarea,select');
+    if (control instanceof HTMLElement) return control;
+  }
+  return null;
+}
+
+function getByLabelText(container: Element, matcher: TextMatch): Element {
+  const result = queryByLabelText(container, matcher);
+  if (!result) {
+    throw new Error(`Unable to find label text: ${matcher.toString()}`);
+  }
+  return result;
+}
+
+function queryByPlaceholderText(container: Element, matcher: TextMatch): Element | null {
+  const inputs = Array.from(container.querySelectorAll('input,textarea'));
+  return inputs.find((input) => matchesText((input as HTMLInputElement | HTMLTextAreaElement).placeholder ?? '', matcher)) ?? null;
+}
+
+function getByPlaceholderText(container: Element, matcher: TextMatch): Element {
+  const result = queryByPlaceholderText(container, matcher);
+  if (!result) {
+    throw new Error(`Unable to find placeholder text: ${matcher.toString()}`);
+  }
+  return result;
+}
+
+function ensureContainer(): HTMLElement {
+  if (!currentContainer) {
+    throw new Error('No rendered container. Call render() first.');
+  }
+  return currentContainer;
+}
+
+export function cleanup() {
+  if (currentRoot) {
+    act(() => {
+      currentRoot?.unmount();
+    });
+    currentRoot = null;
+  }
+  if (currentContainer?.parentElement) {
+    currentContainer.parentElement.removeChild(currentContainer);
+  }
+  currentContainer = null;
+}
+
+export function render(ui: ReactElement): RenderResult {
+  cleanup();
+  const container = document.createElement('div');
+  document.body.appendChild(container);
+  const root = createRoot(container);
+  act(() => {
+    root.render(<StrictMode>{ui}</StrictMode>);
+  });
+  currentRoot = root;
+  currentContainer = container;
+
+  return {
+    container,
+    unmount: cleanup,
+    rerender: (nextUi: ReactElement) => {
+      act(() => {
+        root.render(<StrictMode>{nextUi}</StrictMode>);
+      });
+    },
+  };
+}
+
+function waitForElement(matcher: () => Element | null, options: FindOptions = {}): Promise<Element> {
+  const timeout = options.timeout ?? DEFAULT_TIMEOUT;
+  const interval = options.interval ?? DEFAULT_INTERVAL;
+  const start = Date.now();
+
+  return new Promise<Element>((resolve, reject) => {
+    function check() {
+      try {
+        const result = matcher();
+        if (result) {
+          resolve(result);
+          return;
+        }
+      } catch {
+        // ignore until timeout
+      }
+      if (Date.now() - start >= timeout) {
+        reject(new Error('Timed out waiting for element'));
+        return;
+      }
+      setTimeout(check, interval);
+    }
+    check();
+  });
+}
+
+export function waitFor(callback: () => void, options: FindOptions = {}): Promise<void> {
+  const timeout = options.timeout ?? DEFAULT_TIMEOUT;
+  const interval = options.interval ?? DEFAULT_INTERVAL;
+  const start = Date.now();
+
+  return new Promise<void>((resolve, reject) => {
+    function check() {
+      try {
+        callback();
+        resolve();
+      } catch (error) {
+        if (Date.now() - start >= timeout) {
+          reject(error instanceof Error ? error : new Error('waitFor timeout'));
+          return;
+        }
+        setTimeout(check, interval);
+      }
+    }
+    check();
+  });
+}
+
+export function findByText(matcher: TextMatch, options?: FindOptions): Promise<Element> {
+  return waitForElement(() => queryByText(ensureContainer(), matcher), options);
+}
+
+export function findByRole(role: string, options?: FindOptions): Promise<Element> {
+  return waitForElement(() => queryByRole(ensureContainer(), role, options), options);
+}
+
+export const screen = {
+  get container() {
+    return ensureContainer();
+  },
+  getByText: (matcher: TextMatch) => getByText(ensureContainer(), matcher),
+  queryByText: (matcher: TextMatch) => queryByText(ensureContainer(), matcher),
+  findByText,
+  getByRole: (role: string, options?: QueryOptions) => getByRole(ensureContainer(), role, options),
+  queryByRole: (role: string, options?: QueryOptions) => queryByRole(ensureContainer(), role, options),
+  findByRole,
+  getByLabelText: (matcher: TextMatch) => getByLabelText(ensureContainer(), matcher),
+  getByPlaceholderText: (matcher: TextMatch) => getByPlaceholderText(ensureContainer(), matcher),
+};
+
+export const fireEvent = {
+  click(target: Element) {
+    act(() => {
+      target.dispatchEvent(new MouseEvent('click', { bubbles: true, cancelable: true }));
+    });
+  },
+  change(target: Element, value: string) {
+    act(() => {
+      if (target instanceof HTMLInputElement || target instanceof HTMLTextAreaElement) {
+        target.value = value;
+      }
+      target.dispatchEvent(new Event('input', { bubbles: true }));
+      target.dispatchEvent(new Event('change', { bubbles: true }));
+    });
+  },
+  input(target: Element, value: string) {
+    fireEvent.change(target, value);
+  },
+  submit(target: Element) {
+    act(() => {
+      target.dispatchEvent(new Event('submit', { bubbles: true, cancelable: true }));
+    });
+  },
+};
+
+export function within(element: Element) {
+  return {
+    getByText: (matcher: TextMatch) => getByText(element, matcher),
+    queryByText: (matcher: TextMatch) => queryByText(element, matcher),
+    getByRole: (role: string, options?: QueryOptions) => getByRole(element, role, options),
+    queryByRole: (role: string, options?: QueryOptions) => queryByRole(element, role, options),
+  };
+}
+
+export type {
+  RenderResult,
+  TextMatch,
+};

--- a/src/test-utils/user-event.ts
+++ b/src/test-utils/user-event.ts
@@ -1,0 +1,48 @@
+import { fireEvent } from './testing-library-react';
+
+function delay(ms: number) {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+async function click(element: Element) {
+  fireEvent.click(element);
+  await delay(0);
+}
+
+async function type(element: Element, text: string) {
+  if (!(element instanceof HTMLInputElement || element instanceof HTMLTextAreaElement)) {
+    throw new Error('userEvent.type only supports input and textarea elements in this test harness');
+  }
+  element.focus();
+  let value = '';
+  for (const char of text) {
+    value += char;
+    fireEvent.input(element, value);
+    await delay(0);
+  }
+}
+
+async function clear(element: Element) {
+  if (element instanceof HTMLInputElement || element instanceof HTMLTextAreaElement) {
+    fireEvent.input(element, '');
+    await delay(0);
+  }
+}
+
+async function selectOptions(element: Element, value: string) {
+  if (!(element instanceof HTMLSelectElement)) {
+    throw new Error('userEvent.selectOptions expects a select element');
+  }
+  element.value = value;
+  fireEvent.change(element, value);
+  await delay(0);
+}
+
+export const userEvent = {
+  click,
+  type,
+  clear,
+  selectOptions,
+};
+
+export default userEvent;

--- a/src/utils/permissions.test.ts
+++ b/src/utils/permissions.test.ts
@@ -1,0 +1,62 @@
+import { describe, it, expect } from 'vitest';
+import {
+  applyPermissionUpdates,
+  canAccessLayer,
+  filterItemsByLayerAccess,
+  getAccessibleLayers,
+  type Layer,
+  type PermissionContext,
+  type PermissionUpdate,
+  withRole,
+} from './permissions';
+
+describe('permission utilities', () => {
+  const baseContext: PermissionContext = { role: 'member' };
+
+  it('evaluates access by role hierarchy', () => {
+    expect(canAccessLayer(baseContext, 'public')).toBe(true);
+    expect(canAccessLayer(baseContext, 'trusted')).toBe(true);
+    expect(canAccessLayer(baseContext, 'restricted')).toBe(false);
+
+    const elevated = withRole(baseContext, 'operator');
+    expect(canAccessLayer(elevated, 'restricted')).toBe(true);
+  });
+
+  it('applies overrides while respecting authority', () => {
+    const updates: PermissionUpdate[] = [
+      { layer: 'restricted', allow: true, actorRole: 'operator' },
+      { layer: 'trusted', allow: false, actorRole: 'guest' },
+    ];
+
+    const overridden = applyPermissionUpdates(baseContext, updates);
+    expect(canAccessLayer(overridden, 'restricted')).toBe(true);
+    // Guest cannot revoke trusted access for members
+    expect(canAccessLayer(overridden, 'trusted')).toBe(true);
+  });
+
+  it('filters data based on requested layers and permissions', () => {
+    const items = [
+      { id: '1', layer: 'public' as Layer },
+      { id: '2', layer: 'trusted' as Layer },
+      { id: '3', layer: 'restricted' as Layer },
+    ];
+
+    const memberVisible = filterItemsByLayerAccess(items, baseContext);
+    expect(memberVisible.map((item) => item.id)).toEqual(['1', '2']);
+
+    const operatorContext = withRole(baseContext, 'operator');
+    const restrictedOnly = filterItemsByLayerAccess(
+      items,
+      operatorContext,
+      ['restricted'],
+    );
+    expect(restrictedOnly.map((item) => item.id)).toEqual(['3']);
+  });
+
+  it('updates accessible layer cache after overrides', () => {
+    const updated = applyPermissionUpdates(baseContext, [
+      { layer: 'restricted', allow: true, actorRole: 'operator' },
+    ]);
+    expect(getAccessibleLayers(updated)).toContain('restricted');
+  });
+});

--- a/src/utils/permissions.ts
+++ b/src/utils/permissions.ts
@@ -1,0 +1,137 @@
+export type Layer = 'public' | 'trusted' | 'restricted';
+export type Role = 'guest' | 'member' | 'operator' | 'admin';
+
+export interface PermissionContext {
+  role: Role;
+  overrides?: Partial<Record<Layer, boolean>>;
+}
+
+export interface PermissionUpdate {
+  layer: Layer;
+  allow: boolean;
+  actorRole?: Role;
+}
+
+export interface LayerMetadata {
+  id: Layer;
+  label: string;
+  description: string;
+  minimumRole: Role;
+}
+
+export const LAYERS: LayerMetadata[] = [
+  {
+    id: 'public',
+    label: 'Public',
+    description: 'Broadcast-safe information shared with every operator.',
+    minimumRole: 'guest',
+  },
+  {
+    id: 'trusted',
+    label: 'Trusted',
+    description: 'Confidential signals visible to linked operators.',
+    minimumRole: 'member',
+  },
+  {
+    id: 'restricted',
+    label: 'Restricted',
+    description: 'Highly sensitive intel limited to senior operators.',
+    minimumRole: 'operator',
+  },
+];
+
+const ROLE_HIERARCHY: Role[] = ['guest', 'member', 'operator', 'admin'];
+const ROLE_RANK = ROLE_HIERARCHY.reduce<Record<Role, number>>((acc, role, index) => {
+  acc[role] = index;
+  return acc;
+}, {} as Record<Role, number>);
+
+const BASE_PERMISSIONS: Record<Role, Record<Layer, boolean>> = {
+  guest: {
+    public: true,
+    trusted: false,
+    restricted: false,
+  },
+  member: {
+    public: true,
+    trusted: true,
+    restricted: false,
+  },
+  operator: {
+    public: true,
+    trusted: true,
+    restricted: true,
+  },
+  admin: {
+    public: true,
+    trusted: true,
+    restricted: true,
+  },
+};
+
+function resolveOverrides(context: PermissionContext): Partial<Record<Layer, boolean>> {
+  return context.overrides ? { ...context.overrides } : {};
+}
+
+export function canAccessLayer(context: PermissionContext, layer: Layer): boolean {
+  const overrides = resolveOverrides(context);
+  if (overrides[layer] !== undefined) {
+    return !!overrides[layer];
+  }
+  return BASE_PERMISSIONS[context.role][layer];
+}
+
+export function canManageLayer(role: Role, layer: Layer): boolean {
+  const minimum = LAYERS.find((metadata) => metadata.id === layer)?.minimumRole ?? 'guest';
+  return ROLE_RANK[role] >= ROLE_RANK[minimum];
+}
+
+export function getAccessibleLayers(context: PermissionContext): Layer[] {
+  return LAYERS.map((metadata) => metadata.id).filter((layer) => canAccessLayer(context, layer as Layer));
+}
+
+export function filterItemsByLayerAccess<T extends { layer: Layer }>(
+  items: T[],
+  context: PermissionContext,
+  requestedLayers?: Layer[],
+): T[] {
+  const accessible = new Set(getAccessibleLayers(context));
+  const allowedLayers = requestedLayers
+    ? requestedLayers.filter((layer) => accessible.has(layer))
+    : Array.from(accessible);
+
+  return items.filter((item) => allowedLayers.includes(item.layer));
+}
+
+export function applyPermissionUpdates(
+  context: PermissionContext,
+  updates: PermissionUpdate[],
+): PermissionContext {
+  const overrides = resolveOverrides(context);
+  const next: PermissionContext = {
+    role: context.role,
+    overrides: { ...overrides },
+  };
+
+  for (const update of updates) {
+    const actor = update.actorRole ?? context.role;
+    if (!canManageLayer(actor, update.layer)) {
+      continue;
+    }
+    next.overrides![update.layer] = update.allow;
+  }
+
+  return next;
+}
+
+export function sortLayers(layers: Layer[]): Layer[] {
+  const order = LAYERS.map((layer) => layer.id);
+  return [...layers].sort((a, b) => order.indexOf(a) - order.indexOf(b));
+}
+
+export function withRole(context: PermissionContext, role: Role): PermissionContext {
+  return {
+    role,
+    overrides: resolveOverrides(context),
+  };
+}

--- a/tsconfig.app.json
+++ b/tsconfig.app.json
@@ -13,6 +13,7 @@
     "moduleDetection": "force",
     "noEmit": true,
     "jsx": "react-jsx",
+    "types": ["vitest/globals", "vitest/importMeta"],
 
     /* Linting */
     "strict": true,

--- a/tsconfig.node.json
+++ b/tsconfig.node.json
@@ -18,5 +18,5 @@
     "noUnusedParameters": true,
     "noFallthroughCasesInSwitch": true
   },
-  "include": ["vite.config.ts"]
+  "include": ["vite.config.ts", "vitest.config.ts"]
 }

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,28 @@
+import { defineConfig } from 'vitest/config';
+import react from '@vitejs/plugin-react';
+import path from 'node:path';
+
+export default defineConfig({
+  plugins: [react()],
+  resolve: {
+    alias: {
+      '@testing-library/react': path.resolve(
+        __dirname,
+        'src/test-utils/testing-library-react.tsx',
+      ),
+      '@testing-library/user-event': path.resolve(
+        __dirname,
+        'src/test-utils/user-event.ts',
+      ),
+    },
+  },
+  test: {
+    globals: true,
+    environment: 'jsdom',
+    setupFiles: './src/setupTests.ts',
+    css: true,
+    coverage: {
+      reporter: ['text', 'json', 'html'],
+    },
+  },
+});


### PR DESCRIPTION
## Summary
- add Vitest-based test stack with local testing-library harness and shared setup
- implement permission utilities plus layer-aware stores and wire FieldNotesPanel to the shared filtering
- cover access decisions, layer transitions, and onboarding/content flows with unit and integration tests

## Testing
- npm run lint
- npm run test *(fails: `vitest` executable unavailable in offline environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e2b6dc254c83238d0844ef49fd3bdf