### PR TITLE
feat: add layer filter bar and layer-aware views

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -11,6 +11,7 @@ import { HeaderBar } from './components/interface/HeaderBar';
 import { ControlPanel } from './components/interface/ControlPanel';
 import { BroadcastPanel } from './components/interface/BroadcastPanel';
 import { FieldNotesPanel } from './components/interface/FieldNotesPanel';
+import { LayerFilterBar } from './components/interface/LayerFilterBar';
 
 export function App() {
   const isAuthenticated = useAuthStore((state) => state.isAuthenticated);
@@ -50,6 +51,7 @@ export function App() {
       {isAuthenticated ? (
         <div className="relative z-10 mx-auto flex min-h-screen max-w-7xl flex-col gap-8 px-4 py-6 sm:px-6 lg:px-10">
           <HeaderBar />
+          <LayerFilterBar />
 
           <main className="grid flex-1 gap-6 lg:grid-cols-[320px_minmax(0,1fr)_320px] xl:grid-cols-[340px_minmax(0,1fr)_340px]">
             <ControlPanel />

--- a/src/components/UserNodes.tsx
+++ b/src/components/UserNodes.tsx
@@ -4,13 +4,19 @@ import { Billboard, Text } from '@react-three/drei';
 import { useUserStore } from '../store/userStore';
 import { useAuthStore } from '../store/authStore';
 import { useModalStore } from '../store/modalStore';
+import { useLayerStore } from '../store/layerStore';
 import * as THREE from 'three';
 
 export function UserNodes() {
   const users = useUserStore((state) => state.users);
   const currentUser = useAuthStore((state) => state.user);
   const setProfileUserId = useModalStore((state) => state.setProfileUserId);
+  const isPresenceLayerActive = useLayerStore((state) => state.isLayerActive('presence'));
   const groupRef = useRef<THREE.Group>(null);
+
+  if (!isPresenceLayerActive) {
+    return null;
+  }
 
   useFrame(() => {
     if (groupRef.current) {

--- a/src/components/interface/BroadcastPanel.tsx
+++ b/src/components/interface/BroadcastPanel.tsx
@@ -1,27 +1,43 @@
 import { useMemo, useState, useEffect } from 'react';
-import { Satellite, Waves, MessageSquare, Shield, PlugZap } from 'lucide-react';
+import { Satellite, Waves, MessageSquare, Shield, PlugZap, Power } from 'lucide-react';
 import { useChatStore } from '../../store/chatStore';
 import { useUserStore } from '../../store/userStore';
 import { useAuthStore } from '../../store/authStore';
+import { useLayerStore } from '../../store/layerStore';
 
 export function BroadcastPanel() {
-  const { activeChat, setActiveChat, getMessagesForChat } = useChatStore();
+  const activeChat = useChatStore((state) => state.activeChat);
+  const setActiveChat = useChatStore((state) => state.setActiveChat);
+  const getMessagesForChat = useChatStore((state) => state.getMessagesForChat);
   const currentUser = useAuthStore((state) => state.user);
   const users = useUserStore((state) => state.users);
   const [selectedChannel, setSelectedChannel] = useState(activeChat ?? '');
+  const isBroadcastLayerActive = useLayerStore((state) => state.isLayerActive('broadcasts'));
 
   useEffect(() => {
     setSelectedChannel(activeChat ?? '');
   }, [activeChat]);
 
+  useEffect(() => {
+    if (!isBroadcastLayerActive) {
+      setSelectedChannel('');
+      if (activeChat) {
+        setActiveChat(null);
+      }
+    }
+  }, [activeChat, isBroadcastLayerActive, setActiveChat]);
+
   const otherUsers = useMemo(
-    () => users.filter((user) => user.id !== currentUser?.id),
-    [users, currentUser]
+    () =>
+      (isBroadcastLayerActive ? users : []).filter(
+        (user) => user.id !== currentUser?.id
+      ),
+    [currentUser, isBroadcastLayerActive, users]
   );
 
   const activeUser = otherUsers.find((user) => user.id === activeChat);
   const transcript =
-    currentUser && activeUser
+    currentUser && activeUser && isBroadcastLayerActive
       ? getMessagesForChat(currentUser.id, activeUser.id)
       : [];
 
@@ -37,6 +53,12 @@ export function BroadcastPanel() {
         <span className="rounded-full border border-white/10 px-3 py-1 text-white/60">
           Link Integrity 99%
         </span>
+        {!isBroadcastLayerActive && (
+          <span className="inline-flex items-center gap-2 rounded-full border border-white/10 bg-white/5 px-3 py-1 text-white/50">
+            <Power className="h-3 w-3" />
+            Layer Dormant
+          </span>
+        )}
       </div>
 
       <div className="flex flex-col gap-6 rounded-3xl border border-white/10 bg-slate-950/60 p-6">
@@ -51,83 +73,101 @@ export function BroadcastPanel() {
         </div>
 
         <div className="rounded-2xl border border-white/10 bg-white/5 p-6 text-center">
-          {activeUser ? (
-            <div className="space-y-2">
-              <p className="text-sm uppercase tracking-[0.3em] text-white/50">Active transmission</p>
-              <h3 className="text-2xl font-semibold text-white">{activeUser.name}</h3>
-              <p className="text-sm text-white/60">
-                {transcript.length > 0
-                  ? `Last signal: ${transcript[transcript.length - 1].content}`
-                  : 'Awaiting first transmission...'}
-              </p>
-            </div>
+          {isBroadcastLayerActive ? (
+            activeUser ? (
+              <div className="space-y-2">
+                <p className="text-sm uppercase tracking-[0.3em] text-white/50">Active transmission</p>
+                <h3 className="text-2xl font-semibold text-white">{activeUser.name}</h3>
+                <p className="text-sm text-white/60">
+                  {transcript.length > 0
+                    ? `Last signal: ${transcript[transcript.length - 1].content}`
+                    : 'Awaiting first transmission...'}
+                </p>
+              </div>
+            ) : (
+              <div className="space-y-2">
+                <p className="text-sm uppercase tracking-[0.3em] text-white/50">No transmissions yet</p>
+                <h3 className="text-2xl font-semibold text-white">Select a channel to begin</h3>
+                <p className="text-sm text-white/60">Awaiting link handshake...</p>
+              </div>
+            )
           ) : (
-            <div className="space-y-2">
-              <p className="text-sm uppercase tracking-[0.3em] text-white/50">No transmissions yet</p>
-              <h3 className="text-2xl font-semibold text-white">Select a channel to begin</h3>
-              <p className="text-sm text-white/60">Awaiting link handshake...</p>
+            <div className="flex flex-col items-center gap-3 text-sm text-white/60">
+              <Power className="h-6 w-6 text-white/40" />
+              <p>Broadcast Relays layer disabled.</p>
+              <p className="text-xs text-white/40">Enable to review secure transmissions.</p>
             </div>
           )}
         </div>
 
-        <div className="grid gap-4 md:grid-cols-2">
-          <div className="flex flex-col gap-3 rounded-2xl border border-white/10 bg-white/5 p-4">
-            <label className="text-xs uppercase tracking-[0.3em] text-white/50">
-              Channel Selection
-            </label>
-            <select
-              value={selectedChannel}
-              onChange={(event) => setSelectedChannel(event.target.value)}
-              className="w-full rounded-xl border border-white/10 bg-slate-950/60 px-4 py-3 text-sm text-white focus:border-white/30 focus:outline-none"
-            >
-              <option value="" disabled>
-                Choose linked operator
-              </option>
-              {otherUsers.map((user) => (
-                <option key={user.id} value={user.id}>
-                  {user.name} {user.online ? '(Online)' : '(Offline)'}
-                </option>
-              ))}
-            </select>
-            <p className="text-xs text-white/50">
-              Selecting a channel prepares a private, encrypted relay path.
-            </p>
-          </div>
-
-          <div className="flex flex-col justify-between rounded-2xl border border-white/10 bg-white/5 p-4">
-            <div className="flex items-center justify-between text-sm text-white/60">
-              <span>Handshake Status</span>
-              <Shield className={`h-5 w-5 ${activeUser ? 'text-emerald-300' : 'text-white/40'}`} />
-            </div>
-            <div>
-              <p className="text-lg font-semibold text-white">
-                {activeUser ? 'Secured' : 'Awaiting Link'}
-              </p>
-              <p className="text-xs text-white/50">
-                {activeUser
-                  ? 'Channel authenticated. Ready to transmit.'
-                  : 'Select a channel to initiate the secure handshake.'}
-              </p>
-            </div>
-            <div className="flex items-center gap-2">
-              <button
-                onClick={() => selectedChannel && setActiveChat(selectedChannel)}
-                disabled={!selectedChannel}
-                className="flex-1 rounded-xl border border-emerald-400/40 bg-emerald-500/10 px-4 py-3 text-xs uppercase tracking-[0.3em] text-emerald-300 transition hover:bg-emerald-500/20 disabled:cursor-not-allowed disabled:border-white/10 disabled:bg-white/5 disabled:text-white/40"
+        {isBroadcastLayerActive ? (
+          <div className="grid gap-4 md:grid-cols-2">
+            <div className="flex flex-col gap-3 rounded-2xl border border-white/10 bg-white/5 p-4">
+              <label className="text-xs uppercase tracking-[0.3em] text-white/50">
+                Channel Selection
+              </label>
+              <select
+                value={selectedChannel}
+                onChange={(event) => setSelectedChannel(event.target.value)}
+                className="w-full rounded-xl border border-white/10 bg-slate-950/60 px-4 py-3 text-sm text-white focus:border-white/30 focus:outline-none"
               >
-                {activeUser ? 'Switch Channel' : 'Prepare Sync Capsule'}
-              </button>
-              {activeUser && (
+                <option value="" disabled>
+                  Choose linked operator
+                </option>
+                {otherUsers.map((user) => (
+                  <option key={user.id} value={user.id}>
+                    {user.name} {user.online ? '(Online)' : '(Offline)'}
+                  </option>
+                ))}
+              </select>
+              <p className="text-xs text-white/50">
+                Selecting a channel prepares a private, encrypted relay path.
+              </p>
+            </div>
+
+            <div className="flex flex-col justify-between rounded-2xl border border-white/10 bg-white/5 p-4">
+              <div className="flex items-center justify-between text-sm text-white/60">
+                <span>Handshake Status</span>
+                <Shield className={`h-5 w-5 ${activeUser ? 'text-emerald-300' : 'text-white/40'}`} />
+              </div>
+              <div>
+                <p className="text-lg font-semibold text-white">
+                  {activeUser ? 'Secured' : 'Awaiting Link'}
+                </p>
+                <p className="text-xs text-white/50">
+                  {activeUser
+                    ? 'Channel authenticated. Ready to transmit.'
+                    : 'Select a channel to initiate the secure handshake.'}
+                </p>
+              </div>
+              <div className="flex items-center gap-2">
                 <button
-                  onClick={() => setActiveChat(null)}
-                  className="rounded-xl border border-white/10 bg-white/10 px-4 py-3 text-xs uppercase tracking-[0.3em] text-white/60 transition hover:bg-white/20"
+                  onClick={() => selectedChannel && setActiveChat(selectedChannel)}
+                  disabled={!selectedChannel}
+                  className="flex-1 rounded-xl border border-emerald-400/40 bg-emerald-500/10 px-4 py-3 text-xs uppercase tracking-[0.3em] text-emerald-300 transition hover:bg-emerald-500/20 disabled:cursor-not-allowed disabled:border-white/10 disabled:bg-white/5 disabled:text-white/40"
                 >
-                  Terminate
+                  {activeUser ? 'Switch Channel' : 'Prepare Sync Capsule'}
                 </button>
-              )}
+                {activeUser && (
+                  <button
+                    onClick={() => setActiveChat(null)}
+                    className="rounded-xl border border-white/10 bg-white/10 px-4 py-3 text-xs uppercase tracking-[0.3em] text-white/60 transition hover:bg-white/20"
+                  >
+                    Terminate
+                  </button>
+                )}
+              </div>
             </div>
           </div>
-        </div>
+        ) : (
+          <div className="flex items-center justify-center rounded-2xl border border-white/10 bg-white/5 p-6 text-center text-sm text-white/60">
+            <div className="flex flex-col items-center gap-3">
+              <Power className="h-6 w-6 text-white/40" />
+              <p>Channel controls hidden while Broadcast Relays are dormant.</p>
+              <p className="text-xs text-white/40">Reactivate the layer to manage encrypted links.</p>
+            </div>
+          </div>
+        )}
       </div>
 
       <div className="grid gap-4 md:grid-cols-3">
@@ -137,7 +177,9 @@ export function BroadcastPanel() {
             <MessageSquare className="h-5 w-5 text-sky-300" />
           </div>
           <p className="mt-2 text-xs text-white/50">
-            {transcript.length} encrypted packets stored in session buffer.
+            {isBroadcastLayerActive
+              ? `${transcript.length} encrypted packets stored in session buffer.`
+              : 'Metrics paused while layer is disabled.'}
           </p>
         </div>
         <div className="rounded-2xl border border-white/10 bg-white/5 p-4">
@@ -146,7 +188,11 @@ export function BroadcastPanel() {
             <Waves className="h-5 w-5 text-emerald-300" />
           </div>
           <p className="mt-2 text-xs text-white/50">
-            {activeUser ? 'Live presence detected on linked node.' : 'No active link. Awaiting handshake.'}
+            {isBroadcastLayerActive
+              ? activeUser
+                ? 'Live presence detected on linked node.'
+                : 'No active link. Awaiting handshake.'
+              : 'Synchronization suspended while relays are offline.'}
           </p>
         </div>
         <div className="rounded-2xl border border-white/10 bg-white/5 p-4">
@@ -155,7 +201,9 @@ export function BroadcastPanel() {
             <PlugZap className="h-5 w-5 text-fuchsia-300" />
           </div>
           <p className="mt-2 text-xs text-white/50">
-            All relays operating at nominal capacity.
+            {isBroadcastLayerActive
+              ? 'All relays operating at nominal capacity.'
+              : 'Relays placed in standby; re-enable to restore power state telemetry.'}
           </p>
         </div>
       </div>

--- a/src/components/interface/ControlPanel.tsx
+++ b/src/components/interface/ControlPanel.tsx
@@ -3,17 +3,25 @@ import { useAuthStore } from '../../store/authStore';
 import { useUserStore } from '../../store/userStore';
 import { useChatStore } from '../../store/chatStore';
 import { useModalStore } from '../../store/modalStore';
-import { Activity, ShieldCheck, SignalHigh, Waves } from 'lucide-react';
+import { Activity, ShieldCheck, SignalHigh, Waves, Power } from 'lucide-react';
+import { useLayerStore } from '../../store/layerStore';
 
 export function ControlPanel() {
   const currentUser = useAuthStore((state) => state.user);
   const users = useUserStore((state) => state.users);
-  const onlineUsers = users.filter((user) => user.online);
-  const offlineUsers = users.filter((user) => !user.online);
+  const isPresenceLayerActive = useLayerStore((state) => state.isLayerActive('presence'));
+  const onlineUsers = isPresenceLayerActive
+    ? users.filter((user) => user.online)
+    : [];
+  const offlineUsers = isPresenceLayerActive
+    ? users.filter((user) => !user.online)
+    : [];
   const setActiveChat = useChatStore((state) => state.setActiveChat);
   const setProfileUserId = useModalStore((state) => state.setProfileUserId);
 
-  const otherUsers = users.filter((user) => user.id !== currentUser?.id);
+  const otherUsers = (isPresenceLayerActive ? users : []).filter(
+    (user) => user.id !== currentUser?.id
+  );
 
   return (
     <aside className="space-y-6">
@@ -21,11 +29,11 @@ export function ControlPanel() {
         <div className="pointer-events-none absolute -top-32 -right-10 h-64 w-64 rounded-full bg-cyan-500/30 blur-3xl" />
         <div className="pointer-events-none absolute -bottom-32 -left-20 h-64 w-64 rounded-full bg-indigo-500/20 blur-3xl" />
 
-        <div className="relative flex flex-col gap-6">
-          <div className="flex items-center justify-between">
-            <div>
-              <p className="text-xs uppercase tracking-[0.3em] text-white/50">
-                Control Lattice
+          <div className="relative flex flex-col gap-6">
+            <div className="flex items-center justify-between">
+              <div>
+                <p className="text-xs uppercase tracking-[0.3em] text-white/50">
+                  Control Lattice
               </p>
               <h2 className="mt-1 text-xl font-semibold text-white">
                 Operator Atlas
@@ -38,7 +46,17 @@ export function ControlPanel() {
           </div>
 
           <div className="relative h-64 overflow-hidden rounded-2xl border border-white/10 bg-slate-950/60">
-            <Scene variant="embedded" />
+            {isPresenceLayerActive ? (
+              <Scene variant="embedded" />
+            ) : (
+              <div className="flex h-full items-center justify-center text-center text-sm text-white/60">
+                <div className="flex flex-col items-center gap-2">
+                  <Power className="h-6 w-6 text-white/40" />
+                  <p>Presence Mesh layer disabled.</p>
+                  <p className="text-xs text-white/40">Enable it to visualize operator orbits.</p>
+                </div>
+              </div>
+            )}
             <div className="pointer-events-none absolute inset-0 rounded-2xl border border-white/5" />
           </div>
 
@@ -65,6 +83,11 @@ export function ControlPanel() {
               <p className="mt-2 text-2xl font-semibold text-emerald-300">99.2%</p>
             </div>
           </div>
+          {!isPresenceLayerActive && (
+            <p className="text-xs uppercase tracking-[0.3em] text-white/40">
+              Metrics paused while Presence Mesh is offline.
+            </p>
+          )}
         </div>
       </section>
 
@@ -107,43 +130,53 @@ export function ControlPanel() {
         </div>
 
         <div className="mt-4 space-y-3">
-          {otherUsers.length > 0 ? (
-            otherUsers.map((user) => (
-              <div
-                key={user.id}
-                className="flex items-center justify-between rounded-2xl border border-white/10 bg-white/5 p-3"
-              >
-                <div className="flex items-center gap-3">
-                  <div
-                    className="h-10 w-10 rounded-full border border-white/10"
-                    style={{ backgroundColor: user.color }}
-                  />
-                  <div>
-                    <p className="text-sm font-medium text-white">{user.name}</p>
-                    <p className={`text-xs ${user.online ? 'text-emerald-300' : 'text-white/50'}`}>
-                      {user.online ? 'Online • Synced' : 'Offline • Standby'}
-                    </p>
+          {isPresenceLayerActive ? (
+            otherUsers.length > 0 ? (
+              otherUsers.map((user) => (
+                <div
+                  key={user.id}
+                  className="flex items-center justify-between rounded-2xl border border-white/10 bg-white/5 p-3"
+                >
+                  <div className="flex items-center gap-3">
+                    <div
+                      className="h-10 w-10 rounded-full border border-white/10"
+                      style={{ backgroundColor: user.color }}
+                    />
+                    <div>
+                      <p className="text-sm font-medium text-white">{user.name}</p>
+                      <p className={`text-xs ${user.online ? 'text-emerald-300' : 'text-white/50'}`}>
+                        {user.online ? 'Online • Synced' : 'Offline • Standby'}
+                      </p>
+                    </div>
+                  </div>
+                  <div className="flex items-center gap-2">
+                    <button
+                      onClick={() => setProfileUserId(user.id)}
+                      className="rounded-lg border border-white/10 bg-white/10 px-3 py-2 text-xs uppercase tracking-[0.2em] text-white/60 transition hover:bg-white/20"
+                    >
+                      Profile
+                    </button>
+                    <button
+                      onClick={() => setActiveChat(user.id)}
+                      className="rounded-lg border border-emerald-400/40 bg-emerald-500/10 px-3 py-2 text-xs uppercase tracking-[0.2em] text-emerald-300 transition hover:bg-emerald-500/20"
+                    >
+                      Link
+                    </button>
                   </div>
                 </div>
-                <div className="flex items-center gap-2">
-                  <button
-                    onClick={() => setProfileUserId(user.id)}
-                    className="rounded-lg border border-white/10 bg-white/10 px-3 py-2 text-xs uppercase tracking-[0.2em] text-white/60 transition hover:bg-white/20"
-                  >
-                    Profile
-                  </button>
-                  <button
-                    onClick={() => setActiveChat(user.id)}
-                    className="rounded-lg border border-emerald-400/40 bg-emerald-500/10 px-3 py-2 text-xs uppercase tracking-[0.2em] text-emerald-300 transition hover:bg-emerald-500/20"
-                  >
-                    Link
-                  </button>
-                </div>
+              ))
+            ) : (
+              <div className="rounded-2xl border border-white/10 bg-white/5 p-6 text-center text-sm text-white/50">
+                No auxiliary operators registered.
               </div>
-            ))
+            )
           ) : (
-            <div className="rounded-2xl border border-white/10 bg-white/5 p-6 text-center text-sm text-white/50">
-              No auxiliary operators registered.
+            <div className="rounded-2xl border border-white/10 bg-white/5 p-6 text-center text-sm text-white/60">
+              <div className="flex flex-col items-center gap-2">
+                <Power className="h-5 w-5 text-white/40" />
+                <p>Presence Mesh layer is dormant.</p>
+                <p className="text-xs text-white/40">Enable it to review linked operator dossiers.</p>
+              </div>
             </div>
           )}
         </div>

--- a/src/components/interface/FieldNotesPanel.tsx
+++ b/src/components/interface/FieldNotesPanel.tsx
@@ -1,45 +1,26 @@
-import { useState } from 'react';
-import { NotebookPen, Lock, Save, RefreshCcw, Tag } from 'lucide-react';
+import { useMemo, useState } from 'react';
+import { NotebookPen, Lock, Save, RefreshCcw, Tag, Power } from 'lucide-react';
+import { useFieldNoteStore, FieldNoteTag } from '../../store/fieldNoteStore';
+import { useLayerStore } from '../../store/layerStore';
 
-interface SavedLog {
-  id: string;
-  content: string;
-  timestamp: number;
-  tag: 'Priority' | 'Beacon' | 'Harmony';
-}
-
-const tags: SavedLog['tag'][] = ['Priority', 'Beacon', 'Harmony'];
+const tags: FieldNoteTag[] = ['Priority', 'Beacon', 'Harmony'];
 
 export function FieldNotesPanel() {
   const [draft, setDraft] = useState('');
-  const [selectedTag, setSelectedTag] = useState<SavedLog['tag']>('Priority');
-  const [savedLogs, setSavedLogs] = useState<SavedLog[]>([
-    {
-      id: '1',
-      content: 'Awaiting decoded intel from Node Sigma. Maintain passive watch.',
-      timestamp: Date.now() - 1000 * 60 * 12,
-      tag: 'Beacon',
-    },
-    {
-      id: '2',
-      content: 'Authorize sync capsule for Ops team. Request new clearance tokens.',
-      timestamp: Date.now() - 1000 * 60 * 45,
-      tag: 'Priority',
-    },
-  ]);
+  const [selectedTag, setSelectedTag] = useState<FieldNoteTag>('Priority');
+  const notes = useFieldNoteStore((state) => state.notes);
+  const addNote = useFieldNoteStore((state) => state.addNote);
+  const isNotesLayerActive = useLayerStore((state) => state.isLayerActive('notes'));
+
+  const savedLogs = useMemo(
+    () => [...notes].sort((a, b) => b.timestamp - a.timestamp),
+    [notes]
+  );
 
   const handleSave = () => {
-    if (!draft.trim()) return;
+    if (!draft.trim() || !isNotesLayerActive) return;
 
-    setSavedLogs((prev) => [
-      {
-        id: Date.now().toString(),
-        content: draft.trim(),
-        timestamp: Date.now(),
-        tag: selectedTag,
-      },
-      ...prev,
-    ]);
+    addNote(draft.trim(), selectedTag);
     setDraft('');
   };
 
@@ -68,6 +49,13 @@ export function FieldNotesPanel() {
           <Lock className="h-5 w-5 text-emerald-300" />
         </div>
 
+        {!isNotesLayerActive && (
+          <div className="mt-3 flex items-center gap-2 rounded-2xl border border-white/10 bg-white/5 px-4 py-3 text-xs text-white/60">
+            <Power className="h-4 w-4 text-white/40" />
+            Field Notes layer dormant. Reactivate to compose new intel logs.
+          </div>
+        )}
+
         <div className="mt-5 rounded-2xl border border-white/10 bg-slate-950/60 p-4">
           <div className="mb-3 flex items-center justify-between text-xs uppercase tracking-[0.3em] text-white/50">
             <span>Secure Notepad</span>
@@ -77,7 +65,10 @@ export function FieldNotesPanel() {
             value={draft}
             onChange={(event) => setDraft(event.target.value)}
             placeholder="Compose encrypted field note..."
-            className="h-32 w-full rounded-xl border border-white/10 bg-white/5 px-4 py-3 text-sm text-white placeholder:text-white/40 focus:border-white/30 focus:outline-none"
+            disabled={!isNotesLayerActive}
+            className={`h-32 w-full rounded-xl border border-white/10 bg-white/5 px-4 py-3 text-sm text-white placeholder:text-white/40 focus:border-white/30 focus:outline-none ${
+              isNotesLayerActive ? '' : 'cursor-not-allowed opacity-60'
+            }`}
           />
           <div className="mt-3 flex flex-wrap items-center gap-3">
             <div className="flex items-center gap-2">
@@ -87,11 +78,12 @@ export function FieldNotesPanel() {
                   <button
                     key={tag}
                     onClick={() => setSelectedTag(tag)}
+                    disabled={!isNotesLayerActive}
                     className={`rounded-full border px-3 py-1 text-xs uppercase tracking-[0.3em] transition ${
-                      selectedTag === tag
+                      selectedTag === tag && isNotesLayerActive
                         ? 'border-emerald-400/60 bg-emerald-500/10 text-emerald-300'
                         : 'border-white/10 bg-white/5 text-white/50 hover:bg-white/10'
-                    }`}
+                    } ${!isNotesLayerActive ? 'cursor-not-allowed opacity-50 hover:bg-white/5' : ''}`}
                   >
                     {tag}
                   </button>
@@ -101,13 +93,15 @@ export function FieldNotesPanel() {
             <div className="ml-auto flex items-center gap-2">
               <button
                 onClick={() => setDraft('')}
-                className="rounded-xl border border-white/10 bg-white/10 px-4 py-2 text-xs uppercase tracking-[0.3em] text-white/60 transition hover:bg-white/20"
+                disabled={!isNotesLayerActive}
+                className="rounded-xl border border-white/10 bg-white/10 px-4 py-2 text-xs uppercase tracking-[0.3em] text-white/60 transition hover:bg-white/20 disabled:cursor-not-allowed disabled:bg-white/5 disabled:text-white/30"
               >
                 Clear
               </button>
               <button
                 onClick={handleSave}
-                className="rounded-xl border border-emerald-400/40 bg-emerald-500/10 px-4 py-2 text-xs uppercase tracking-[0.3em] text-emerald-300 transition hover:bg-emerald-500/20"
+                disabled={!isNotesLayerActive || !draft.trim()}
+                className="rounded-xl border border-emerald-400/40 bg-emerald-500/10 px-4 py-2 text-xs uppercase tracking-[0.3em] text-emerald-300 transition hover:bg-emerald-500/20 disabled:cursor-not-allowed disabled:border-white/10 disabled:bg-white/5 disabled:text-white/30"
               >
                 <span className="flex items-center gap-2"><Save className="h-4 w-4" /> Save Log</span>
               </button>
@@ -122,32 +116,42 @@ export function FieldNotesPanel() {
           <RefreshCcw className="h-4 w-4 text-white/40" />
         </div>
         <div className="mt-4 space-y-3">
-          {savedLogs.length > 0 ? (
-            savedLogs.map((log) => (
-              <div
-                key={log.id}
-                className="rounded-2xl border border-white/10 bg-white/5 p-4"
-              >
-                <div className="flex items-center justify-between text-xs uppercase tracking-[0.3em] text-white/50">
-                  <span>{formatTime(log.timestamp)}</span>
-                  <span
-                    className={`rounded-full border px-3 py-1 ${
-                      log.tag === 'Priority'
-                        ? 'border-rose-400/40 bg-rose-500/10 text-rose-200'
-                        : log.tag === 'Beacon'
-                        ? 'border-sky-400/40 bg-sky-500/10 text-sky-200'
-                        : 'border-emerald-400/40 bg-emerald-500/10 text-emerald-200'
-                    }`}
-                  >
-                    {log.tag}
-                  </span>
+          {isNotesLayerActive ? (
+            savedLogs.length > 0 ? (
+              savedLogs.map((log) => (
+                <div
+                  key={log.id}
+                  className="rounded-2xl border border-white/10 bg-white/5 p-4"
+                >
+                  <div className="flex items-center justify-between text-xs uppercase tracking-[0.3em] text-white/50">
+                    <span>{formatTime(log.timestamp)}</span>
+                    <span
+                      className={`rounded-full border px-3 py-1 ${
+                        log.tag === 'Priority'
+                          ? 'border-rose-400/40 bg-rose-500/10 text-rose-200'
+                          : log.tag === 'Beacon'
+                          ? 'border-sky-400/40 bg-sky-500/10 text-sky-200'
+                          : 'border-emerald-400/40 bg-emerald-500/10 text-emerald-200'
+                      }`}
+                    >
+                      {log.tag}
+                    </span>
+                  </div>
+                  <p className="mt-3 text-sm text-white/70">{log.content}</p>
                 </div>
-                <p className="mt-3 text-sm text-white/70">{log.content}</p>
+              ))
+            ) : (
+              <div className="rounded-2xl border border-white/10 bg-white/5 p-6 text-center text-sm text-white/50">
+                No saved logs yet.
               </div>
-            ))
+            )
           ) : (
-            <div className="rounded-2xl border border-white/10 bg-white/5 p-6 text-center text-sm text-white/50">
-              No saved logs yet.
+            <div className="rounded-2xl border border-white/10 bg-white/5 p-6 text-center text-sm text-white/60">
+              <div className="flex flex-col items-center gap-3">
+                <Power className="h-5 w-5 text-white/40" />
+                <p>Logs redacted while Field Notes layer is dormant.</p>
+                <p className="text-xs text-white/40">Enable visibility to review historical intel.</p>
+              </div>
             </div>
           )}
         </div>

--- a/src/components/interface/LayerFilterBar.tsx
+++ b/src/components/interface/LayerFilterBar.tsx
@@ -1,0 +1,150 @@
+import { useMemo } from 'react';
+import { ShieldCheck, Waves, Notebook, Images } from 'lucide-react';
+import { useLayerStore, LayerId } from '../../store/layerStore';
+import { useUserStore } from '../../store/userStore';
+import { useChatStore } from '../../store/chatStore';
+import { useStoryStore } from '../../store/storyStore';
+import { useFieldNoteStore } from '../../store/fieldNoteStore';
+
+const layerIcons: Record<LayerId, typeof ShieldCheck> = {
+  presence: ShieldCheck,
+  broadcasts: Waves,
+  notes: Notebook,
+  media: Images,
+};
+
+const accentClasses: Record<LayerId, { active: string; inactive: string; badge: string }> = {
+  presence: {
+    active: 'border-emerald-400/50 bg-emerald-500/10 text-emerald-200',
+    inactive: 'border-emerald-400/20 bg-emerald-500/5 text-emerald-200/60',
+    badge: 'bg-emerald-500/20 text-emerald-200',
+  },
+  broadcasts: {
+    active: 'border-sky-400/50 bg-sky-500/10 text-sky-200',
+    inactive: 'border-sky-400/20 bg-sky-500/5 text-sky-200/60',
+    badge: 'bg-sky-500/20 text-sky-200',
+  },
+  notes: {
+    active: 'border-amber-400/50 bg-amber-500/10 text-amber-200',
+    inactive: 'border-amber-400/20 bg-amber-500/5 text-amber-200/60',
+    badge: 'bg-amber-500/20 text-amber-200',
+  },
+  media: {
+    active: 'border-violet-400/50 bg-violet-500/10 text-violet-200',
+    inactive: 'border-violet-400/20 bg-violet-500/5 text-violet-200/60',
+    badge: 'bg-violet-500/20 text-violet-200',
+  },
+};
+
+export function LayerFilterBar() {
+  const layers = useLayerStore((state) => state.layers);
+  const activeLayerIds = useLayerStore((state) => state.activeLayerIds);
+  const toggleLayer = useLayerStore((state) => state.toggleLayer);
+
+  const { totalUsers, onlineUsers } = useUserStore((state) => ({
+    totalUsers: state.users.length,
+    onlineUsers: state.users.filter((user) => user.online).length,
+  }));
+
+  const { messageCount, channelCount } = useChatStore((state) => {
+    const uniqueChannels = new Set<string>();
+    state.messages.forEach((message) => {
+      const key = [message.fromUserId, message.toUserId].sort().join('::');
+      uniqueChannels.add(key);
+    });
+
+    return {
+      messageCount: state.messages.length,
+      channelCount: uniqueChannels.size,
+    };
+  });
+
+  const noteCount = useFieldNoteStore((state) => state.notes.length);
+  const storyCount = useStoryStore((state) => state.stories.length);
+
+  const layerMetrics = useMemo(
+    () => ({
+      presence: {
+        badge: `${onlineUsers}/${totalUsers}`,
+        tooltip: `${onlineUsers} operators visible of ${totalUsers} registered`,
+      },
+      broadcasts: {
+        badge: `${channelCount} ch`,
+        tooltip:
+          channelCount === 0
+            ? 'No secure channels ready'
+            : `${channelCount} secure ${channelCount === 1 ? 'channel' : 'channels'} with ${messageCount} transmissions logged`,
+      },
+      notes: {
+        badge: `${noteCount}`,
+        tooltip:
+          noteCount === 1
+            ? '1 field note archived'
+            : `${noteCount} field notes archived`,
+      },
+      media: {
+        badge: `${storyCount}`,
+        tooltip:
+          storyCount === 1
+            ? '1 media artifact in vault'
+            : `${storyCount} media artifacts in vault`,
+      },
+    }),
+    [channelCount, messageCount, noteCount, onlineUsers, storyCount, totalUsers]
+  );
+
+  return (
+    <nav className="rounded-3xl border border-white/10 bg-white/5 p-4 shadow-[0_20px_60px_-30px_rgba(15,23,42,0.8)]">
+      <div className="flex flex-wrap items-center justify-between gap-4">
+        <div className="space-y-1">
+          <p className="text-xs uppercase tracking-[0.3em] text-white/50">Layer Filters</p>
+          <p className="text-sm text-white/70">
+            Toggle operational layers to refine visible intelligence.
+          </p>
+        </div>
+        <div className="flex flex-wrap gap-3">
+          {layers.map((layer) => {
+            const Icon = layerIcons[layer.id];
+            const isActive = activeLayerIds.includes(layer.id);
+            const accent = accentClasses[layer.id];
+            const metric = layerMetrics[layer.id];
+
+            return (
+              <button
+                key={layer.id}
+                type="button"
+                onClick={() => toggleLayer(layer.id)}
+                aria-pressed={isActive}
+                title={`${layer.description}\n${metric.tooltip}`}
+                className={`group flex items-center gap-3 rounded-2xl border px-4 py-3 text-left transition hover:border-white/20 hover:bg-white/10 focus:outline-none focus-visible:ring-2 focus-visible:ring-white/40 ${
+                  isActive ? accent.active : accent.inactive
+                }`}
+              >
+                <span className="flex items-center gap-2">
+                  <span
+                    className={`flex h-8 w-8 items-center justify-center rounded-xl border text-sm ${
+                      isActive ? 'border-white/20 bg-white/10 text-white' : 'border-white/10 bg-white/5 text-white/60'
+                    }`}
+                  >
+                    <Icon className="h-4 w-4" />
+                  </span>
+                  <span className="flex flex-col">
+                    <span className="text-xs uppercase tracking-[0.2em] text-white/60">
+                      {isActive ? 'Active' : 'Dormant'}
+                    </span>
+                    <span className="text-sm font-semibold text-white">{layer.name}</span>
+                  </span>
+                </span>
+                <span
+                  className={`ml-4 rounded-full px-3 py-1 text-xs font-medium uppercase tracking-[0.2em] ${accent.badge}`}
+                >
+                  {metric.badge}
+                </span>
+              </button>
+            );
+          })}
+        </div>
+      </div>
+    </nav>
+  );
+}

--- a/src/components/profile/ProfileModal.tsx
+++ b/src/components/profile/ProfileModal.tsx
@@ -7,6 +7,7 @@ import { useStoryStore } from '../../store/storyStore';
 import { useState, useRef } from 'react';
 import { StoryViewer } from './StoryViewer';
 import { StoryCreator } from './StoryCreator';
+import { useLayerStore } from '../../store/layerStore';
 
 interface ProfileModalProps {
   userId: string;
@@ -20,6 +21,7 @@ export function ProfileModal({ userId, onClose }: ProfileModalProps) {
   const { sendFriendRequest, isFriend, hasPendingRequest } = useFriendStore();
   const setActiveChat = useChatStore((state) => state.setActiveChat);
   const stories = useStoryStore((state) => state.getActiveStoriesForUser(userId));
+  const isMediaLayerActive = useLayerStore((state) => state.isLayerActive('media'));
   
   const [isEditing, setIsEditing] = useState(false);
   const [editName, setEditName] = useState('');
@@ -160,18 +162,25 @@ export function ProfileModal({ userId, onClose }: ProfileModalProps) {
               {isOwnProfile && (
                 <button
                   onClick={() => setShowStoryCreator(true)}
-                  className="text-sm px-3 py-1 bg-white/20 hover:bg-white/30 rounded-lg text-white transition-colors"
+                  disabled={!isMediaLayerActive}
+                  className="text-sm px-3 py-1 bg-white/20 hover:bg-white/30 rounded-lg text-white transition-colors disabled:cursor-not-allowed disabled:bg-white/10 disabled:text-white/40"
                 >
                   Add Story
                 </button>
               )}
             </div>
-            {stories.length > 0 ? (
-              <div className="flex space-x-2 overflow-x-auto pb-2">
-                <StoryViewer stories={stories} />
-              </div>
+            {isMediaLayerActive ? (
+              stories.length > 0 ? (
+                <div className="flex space-x-2 overflow-x-auto pb-2">
+                  <StoryViewer stories={stories} />
+                </div>
+              ) : (
+                <p className="text-white/50">No active stories</p>
+              )
             ) : (
-              <p className="text-white/50">No active stories</p>
+              <div className="rounded-xl border border-white/10 bg-white/5 p-4 text-sm text-white/60">
+                Media Vault layer is dormant. Enable to review shared stories.
+              </div>
             )}
           </div>
 
@@ -207,7 +216,7 @@ export function ProfileModal({ userId, onClose }: ProfileModalProps) {
           )}
         </div>
 
-        {showStoryCreator && (
+        {showStoryCreator && isMediaLayerActive && (
           <StoryCreator onClose={() => setShowStoryCreator(false)} />
         )}
       </div>

--- a/src/store/fieldNoteStore.ts
+++ b/src/store/fieldNoteStore.ts
@@ -1,0 +1,46 @@
+import { create } from 'zustand';
+
+export type FieldNoteTag = 'Priority' | 'Beacon' | 'Harmony';
+
+export interface FieldNote {
+  id: string;
+  content: string;
+  timestamp: number;
+  tag: FieldNoteTag;
+}
+
+interface FieldNoteState {
+  notes: FieldNote[];
+  addNote: (content: string, tag: FieldNoteTag) => void;
+}
+
+const DEFAULT_NOTES: FieldNote[] = [
+  {
+    id: '1',
+    content: 'Awaiting decoded intel from Node Sigma. Maintain passive watch.',
+    timestamp: Date.now() - 1000 * 60 * 12,
+    tag: 'Beacon',
+  },
+  {
+    id: '2',
+    content: 'Authorize sync capsule for Ops team. Request new clearance tokens.',
+    timestamp: Date.now() - 1000 * 60 * 45,
+    tag: 'Priority',
+  },
+];
+
+export const useFieldNoteStore = create<FieldNoteState>((set) => ({
+  notes: DEFAULT_NOTES,
+  addNote: (content, tag) =>
+    set((state) => ({
+      notes: [
+        {
+          id: Date.now().toString(),
+          content,
+          timestamp: Date.now(),
+          tag,
+        },
+        ...state.notes,
+      ],
+    })),
+}));

--- a/src/store/layerStore.ts
+++ b/src/store/layerStore.ts
@@ -1,0 +1,71 @@
+import { create } from 'zustand';
+
+export type LayerId = 'presence' | 'broadcasts' | 'notes' | 'media';
+
+export interface Layer {
+  id: LayerId;
+  name: string;
+  description: string;
+}
+
+interface LayerState {
+  layers: Layer[];
+  activeLayerIds: LayerId[];
+  toggleLayer: (layerId: LayerId) => void;
+  setLayerActive: (layerId: LayerId, active: boolean) => void;
+  isLayerActive: (layerId: LayerId) => boolean;
+}
+
+const DEFAULT_LAYERS: Layer[] = [
+  {
+    id: 'presence',
+    name: 'Presence Mesh',
+    description: 'Operator visibility, status, and spatial overlays.',
+  },
+  {
+    id: 'broadcasts',
+    name: 'Broadcast Relays',
+    description: 'Secure message feeds and live channel telemetry.',
+  },
+  {
+    id: 'notes',
+    name: 'Field Notes',
+    description: 'Mission annotations and logged directives.',
+  },
+  {
+    id: 'media',
+    name: 'Media Vault',
+    description: 'Stories, imagery, and shared intelligence captures.',
+  },
+];
+
+export const useLayerStore = create<LayerState>((set, get) => ({
+  layers: DEFAULT_LAYERS,
+  activeLayerIds: DEFAULT_LAYERS.map((layer) => layer.id),
+
+  toggleLayer: (layerId) => {
+    const { activeLayerIds } = get();
+    const isActive = activeLayerIds.includes(layerId);
+    const nextActive = isActive
+      ? activeLayerIds.filter((id) => id !== layerId)
+      : [...activeLayerIds, layerId];
+
+    set({ activeLayerIds: nextActive });
+  },
+
+  setLayerActive: (layerId, active) => {
+    const { activeLayerIds } = get();
+    const hasLayer = activeLayerIds.includes(layerId);
+
+    if (active && !hasLayer) {
+      set({ activeLayerIds: [...activeLayerIds, layerId] });
+      return;
+    }
+
+    if (!active && hasLayer) {
+      set({ activeLayerIds: activeLayerIds.filter((id) => id !== layerId) });
+    }
+  },
+
+  isLayerActive: (layerId) => get().activeLayerIds.includes(layerId),
+}));


### PR DESCRIPTION
## Summary
- add a dedicated layer store and surface a LayerFilterBar with live metrics and toggles
- update control, broadcast, notes, and media panels to react to active layer state and provide dormant messaging
- centralize field note data in a store for consistent counts across the interface

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e2b6bf642883239354aeee5c2d3445