### PR TITLE
Implement layered permission model across stores

### DIFF
--- a/src/components/FriendRequests.tsx
+++ b/src/components/FriendRequests.tsx
@@ -11,12 +11,14 @@ interface FriendRequestsProps {
 export function FriendRequests({ className }: FriendRequestsProps) {
   const [isOpen, setIsOpen] = useState(false);
   const currentUser = useAuthStore((state) => state.user);
-  const users = useUserStore((state) => state.users);
-  const { friendRequests, acceptFriendRequest, rejectFriendRequest } = useFriendStore();
+  const getVisibleUsers = useUserStore((state) => state.getVisibleUsers);
+  const { getVisibleRequests, acceptFriendRequest, rejectFriendRequest } = useFriendStore();
 
   if (!currentUser) return null;
 
-  const pendingRequests = friendRequests.filter(
+  const visibleRequests = getVisibleRequests(currentUser.id);
+  const visibleUsers = getVisibleUsers(currentUser.id);
+  const pendingRequests = visibleRequests.filter(
     (request) =>
       request.status === 'pending' && request.toUserId === currentUser.id
   );
@@ -44,7 +46,7 @@ export function FriendRequests({ className }: FriendRequestsProps) {
           {pendingRequests.length > 0 ? (
             <div className="divide-y divide-white/10">
               {pendingRequests.map((request) => {
-                const fromUser = users.find((u) => u.id === request.fromUserId);
+                const fromUser = visibleUsers.find((u) => u.id === request.fromUserId);
                 if (!fromUser) return null;
 
                 return (
@@ -61,13 +63,13 @@ export function FriendRequests({ className }: FriendRequestsProps) {
                     </div>
                     <div className="flex space-x-2">
                       <button
-                        onClick={() => acceptFriendRequest(request.id)}
+                        onClick={() => acceptFriendRequest(request.id, currentUser.id)}
                         className="px-3 py-1 bg-emerald-500/20 text-emerald-300 rounded hover:bg-emerald-500/30 transition-colors"
                       >
                         Accept
                       </button>
                       <button
-                        onClick={() => rejectFriendRequest(request.id)}
+                        onClick={() => rejectFriendRequest(request.id, currentUser.id)}
                         className="px-3 py-1 bg-red-500/20 text-red-300 rounded hover:bg-red-500/30 transition-colors"
                       >
                         Reject

--- a/src/components/SearchBar.tsx
+++ b/src/components/SearchBar.tsx
@@ -2,6 +2,7 @@ import { Search } from 'lucide-react';
 import { useState } from 'react';
 import { useUserStore } from '../store/userStore';
 import { useModalStore } from '../store/modalStore';
+import { useAuthStore } from '../store/authStore';
 
 interface SearchBarProps {
   className?: string;
@@ -9,7 +10,10 @@ interface SearchBarProps {
 
 export function SearchBar({ className }: SearchBarProps) {
   const [query, setQuery] = useState('');
-  const users = useUserStore((state) => state.users);
+  const currentUser = useAuthStore((state) => state.user);
+  const users = useUserStore((state) =>
+    currentUser ? state.getVisibleUsers(currentUser.id) : []
+  );
   const setProfileUserId = useModalStore((state) => state.setProfileUserId);
 
   const filteredUsers = users.filter((user) =>

--- a/src/components/UserNodes.tsx
+++ b/src/components/UserNodes.tsx
@@ -7,7 +7,7 @@ import { useModalStore } from '../store/modalStore';
 import * as THREE from 'three';
 
 export function UserNodes() {
-  const users = useUserStore((state) => state.users);
+  const getOnlineUsers = useUserStore((state) => state.getOnlineUsers);
   const currentUser = useAuthStore((state) => state.user);
   const setProfileUserId = useModalStore((state) => state.setProfileUserId);
   const groupRef = useRef<THREE.Group>(null);
@@ -24,7 +24,7 @@ export function UserNodes() {
     }
   }, []);
 
-  const onlineUsers = users.filter(user => user.online);
+  const onlineUsers = currentUser ? getOnlineUsers(currentUser.id) : [];
   const radius = 3;
   const nodeRadius = 0.2;
 

--- a/src/components/chat/ChatWindow.tsx
+++ b/src/components/chat/ChatWindow.tsx
@@ -13,12 +13,16 @@ export function ChatWindow({ userId, onClose }: ChatWindowProps) {
   const [message, setMessage] = useState('');
   const messagesEndRef = useRef<HTMLDivElement>(null);
   const currentUser = useAuthStore((state) => state.user);
-  const otherUser = useUserStore((state) => state.users.find(u => u.id === userId));
+  const otherUser = useUserStore((state) =>
+    currentUser
+      ? state.getVisibleUsers(currentUser.id).find((u) => u.id === userId)
+      : undefined
+  );
   const { sendMessage, getMessagesForChat } = useChatStore();
 
   const messages = useMemo(() => {
     if (!currentUser) return [];
-    return getMessagesForChat(currentUser.id, userId);
+    return getMessagesForChat(currentUser.id, userId, currentUser.id);
   }, [currentUser, getMessagesForChat, userId]);
 
   const scrollToBottom = () => {
@@ -33,7 +37,13 @@ export function ChatWindow({ userId, onClose }: ChatWindowProps) {
     e.preventDefault();
     if (!message.trim() || !currentUser) return;
 
-    sendMessage(currentUser.id, userId, message.trim());
+    sendMessage({
+      fromUserId: currentUser.id,
+      toUserId: userId,
+      content: message.trim(),
+      layerIds: currentUser.layerIds,
+      visibility: currentUser.visibility,
+    });
     setMessage('');
   };
 

--- a/src/components/interface/BroadcastPanel.tsx
+++ b/src/components/interface/BroadcastPanel.tsx
@@ -7,7 +7,9 @@ import { useAuthStore } from '../../store/authStore';
 export function BroadcastPanel() {
   const { activeChat, setActiveChat, getMessagesForChat } = useChatStore();
   const currentUser = useAuthStore((state) => state.user);
-  const users = useUserStore((state) => state.users);
+  const visibleUsers = useUserStore((state) =>
+    currentUser ? state.getVisibleUsers(currentUser.id) : []
+  );
   const [selectedChannel, setSelectedChannel] = useState(activeChat ?? '');
 
   useEffect(() => {
@@ -15,14 +17,14 @@ export function BroadcastPanel() {
   }, [activeChat]);
 
   const otherUsers = useMemo(
-    () => users.filter((user) => user.id !== currentUser?.id),
-    [users, currentUser]
+    () => visibleUsers.filter((user) => user.id !== currentUser?.id),
+    [visibleUsers, currentUser]
   );
 
   const activeUser = otherUsers.find((user) => user.id === activeChat);
   const transcript =
     currentUser && activeUser
-      ? getMessagesForChat(currentUser.id, activeUser.id)
+      ? getMessagesForChat(currentUser.id, activeUser.id, currentUser.id)
       : [];
 
   return (

--- a/src/components/interface/ControlPanel.tsx
+++ b/src/components/interface/ControlPanel.tsx
@@ -7,13 +7,15 @@ import { Activity, ShieldCheck, SignalHigh, Waves } from 'lucide-react';
 
 export function ControlPanel() {
   const currentUser = useAuthStore((state) => state.user);
-  const users = useUserStore((state) => state.users);
-  const onlineUsers = users.filter((user) => user.online);
-  const offlineUsers = users.filter((user) => !user.online);
+  const visibleUsers = useUserStore((state) =>
+    currentUser ? state.getVisibleUsers(currentUser.id) : []
+  );
+  const onlineUsers = visibleUsers.filter((user) => user.online);
+  const offlineUsers = visibleUsers.filter((user) => !user.online);
   const setActiveChat = useChatStore((state) => state.setActiveChat);
   const setProfileUserId = useModalStore((state) => state.setProfileUserId);
 
-  const otherUsers = users.filter((user) => user.id !== currentUser?.id);
+  const otherUsers = visibleUsers.filter((user) => user.id !== currentUser?.id);
 
   return (
     <aside className="space-y-6">

--- a/src/components/profile/ProfileModal.tsx
+++ b/src/components/profile/ProfileModal.tsx
@@ -14,27 +14,38 @@ interface ProfileModalProps {
 }
 
 export function ProfileModal({ userId, onClose }: ProfileModalProps) {
-  const user = useUserStore((state) => state.users.find(u => u.id === userId));
+  const getVisibleUsers = useUserStore((state) => state.getVisibleUsers);
   const currentUser = useAuthStore((state) => state.user);
   const updateProfile = useAuthStore((state) => state.updateProfile);
   const { sendFriendRequest, isFriend, hasPendingRequest } = useFriendStore();
   const setActiveChat = useChatStore((state) => state.setActiveChat);
-  const stories = useStoryStore((state) => state.getActiveStoriesForUser(userId));
+  const getStoriesForUser = useStoryStore((state) => state.getActiveStoriesForUser);
   
   const [isEditing, setIsEditing] = useState(false);
   const [editName, setEditName] = useState('');
   const [showStoryCreator, setShowStoryCreator] = useState(false);
   const fileInputRef = useRef<HTMLInputElement>(null);
 
-  if (!user || !currentUser) return null;
+  if (!currentUser) return null;
+
+  const visibleUsers = getVisibleUsers(currentUser.id);
+  const user = visibleUsers.find(u => u.id === userId);
+
+  if (!user) return null;
 
   const isOwnProfile = currentUser.id === userId;
-  const areFriends = isFriend(currentUser.id, userId);
-  const hasPending = hasPendingRequest(currentUser.id, userId);
+  const areFriends = isFriend(currentUser.id, userId, currentUser.id);
+  const hasPending = hasPendingRequest(currentUser.id, userId, currentUser.id);
+  const stories = getStoriesForUser(userId, currentUser.id);
 
   const handleFriendRequest = () => {
     if (!hasPending) {
-      sendFriendRequest(currentUser.id, userId);
+      sendFriendRequest({
+        fromUserId: currentUser.id,
+        toUserId: userId,
+        layerIds: currentUser.layerIds,
+        visibility: currentUser.visibility,
+      });
     }
   };
 

--- a/src/components/profile/StoryCreator.tsx
+++ b/src/components/profile/StoryCreator.tsx
@@ -28,7 +28,13 @@ export function StoryCreator({ onClose }: StoryCreatorProps) {
   const handleSubmit = (e: React.FormEvent) => {
     e.preventDefault();
     if (currentUser && content.trim()) {
-      addStory(currentUser.id, content.trim(), imagePreview || undefined);
+      addStory({
+        userId: currentUser.id,
+        content: content.trim(),
+        image: imagePreview || undefined,
+        layerIds: currentUser.layerIds,
+        visibility: currentUser.visibility,
+      });
       onClose();
     }
   };

--- a/src/lib/permissions.ts
+++ b/src/lib/permissions.ts
@@ -1,0 +1,110 @@
+import { useLayerStore } from '../store/layerStore';
+
+export enum Visibility {
+  PUBLIC = 'public',
+  MEMBERS = 'members',
+  PRIVATE = 'private',
+}
+
+export interface AccessControlledEntity {
+  ownerId?: string | null;
+  layerIds: string[];
+  visibility: Visibility;
+}
+
+const normalizeLayerIds = (layerIds?: string[]) =>
+  Array.from(new Set((layerIds ?? []).filter(Boolean)));
+
+export const resolveLayerIds = (layerIds?: string[]) => {
+  const normalized = normalizeLayerIds(layerIds);
+  if (normalized.length > 0) {
+    return normalized;
+  }
+  const { getDefaultLayerId } = useLayerStore.getState();
+  return [getDefaultLayerId()];
+};
+
+export const userHasLayerAccess = (
+  userId: string | null | undefined,
+  layerIds: string[]
+) => {
+  if (!userId) {
+    return false;
+  }
+
+  const normalized = resolveLayerIds(layerIds);
+  const { userHasAccessToLayers } = useLayerStore.getState();
+  return userHasAccessToLayers(userId, normalized);
+};
+
+export const canReadEntity = (
+  userId: string | null | undefined,
+  entity: AccessControlledEntity
+) => {
+  switch (entity.visibility) {
+    case Visibility.PUBLIC:
+      return true;
+    case Visibility.PRIVATE:
+      return Boolean(entity.ownerId && entity.ownerId === userId);
+    case Visibility.MEMBERS:
+    default:
+      if (!userId) {
+        return false;
+      }
+      return (
+        userHasLayerAccess(userId, resolveLayerIds(entity.layerIds)) ||
+        (entity.ownerId ? entity.ownerId === userId : false)
+      );
+  }
+};
+
+export const canWriteEntity = (
+  userId: string | null | undefined,
+  entity: AccessControlledEntity
+) => {
+  if (!userId) {
+    return false;
+  }
+
+  if (entity.ownerId && entity.ownerId === userId) {
+    return true;
+  }
+
+  if (entity.visibility === Visibility.PRIVATE) {
+    return false;
+  }
+
+  return userHasLayerAccess(userId, resolveLayerIds(entity.layerIds));
+};
+
+export const filterReadableEntities = <T extends AccessControlledEntity>(
+  userId: string | null | undefined,
+  entities: T[]
+) => entities.filter((entity) => canReadEntity(userId, entity));
+
+export const assertCanRead = (
+  userId: string | null | undefined,
+  entity: AccessControlledEntity,
+  errorMessage = 'You do not have permission to view this content.'
+) => {
+  if (!canReadEntity(userId, entity)) {
+    throw new Error(errorMessage);
+  }
+};
+
+export const assertCanWrite = (
+  userId: string | null | undefined,
+  entity: AccessControlledEntity,
+  errorMessage = 'You do not have permission to modify this content.'
+) => {
+  if (!canWriteEntity(userId, entity)) {
+    throw new Error(errorMessage);
+  }
+};
+
+export const withDefaultAccessControl = <T extends AccessControlledEntity>(
+  entity: Omit<T, 'layerIds'> & Partial<Pick<T, 'layerIds'>>
+): T => ({
+  ...entity,
+  layerIds: resolveLayerIds(entity.layerIds),
+});

--- a/src/store/chatStore.ts
+++ b/src/store/chatStore.ts
@@ -1,46 +1,71 @@
 import { create } from 'zustand';
+import {
+  AccessControlledEntity,
+  Visibility,
+  canReadEntity,
+  resolveLayerIds,
+} from '../lib/permissions';
 
-interface Message {
+export interface Message extends AccessControlledEntity {
   id: string;
   fromUserId: string;
   toUserId: string;
+  ownerId: string;
   content: string;
   timestamp: number;
+}
+
+interface SendMessageInput {
+  fromUserId: string;
+  toUserId: string;
+  content: string;
+  layerIds?: string[];
+  visibility?: Visibility;
 }
 
 interface ChatState {
   activeChat: string | null;
   messages: Message[];
   setActiveChat: (userId: string | null) => void;
-  sendMessage: (fromUserId: string, toUserId: string, content: string) => void;
-  getMessagesForChat: (userId1: string, userId2: string) => Message[];
+  sendMessage: (input: SendMessageInput) => void;
+  getMessagesForChat: (
+    userId1: string,
+    userId2: string,
+    viewerId?: string | null
+  ) => Message[];
 }
 
 export const useChatStore = create<ChatState>((set, get) => ({
   activeChat: null,
   messages: [],
-  
+
   setActiveChat: (userId) => set({ activeChat: userId }),
-  
-  sendMessage: (fromUserId, toUserId, content) => {
-    const newMessage: Message = {
-      id: Date.now().toString(),
+
+  sendMessage: ({ fromUserId, toUserId, content, layerIds, visibility }) => {
+    const timestamp = Date.now();
+    const message: Message = {
+      id: timestamp.toString(),
       fromUserId,
       toUserId,
+      ownerId: fromUserId,
       content,
-      timestamp: Date.now(),
+      timestamp,
+      layerIds: resolveLayerIds(layerIds),
+      visibility: visibility ?? Visibility.MEMBERS,
     };
-    
+
     set((state) => ({
-      messages: [...state.messages, newMessage],
+      messages: [...state.messages, message],
     }));
   },
-  
-  getMessagesForChat: (userId1, userId2) => {
-    return get().messages.filter(
-      (msg) =>
-        (msg.fromUserId === userId1 && msg.toUserId === userId2) ||
-        (msg.fromUserId === userId2 && msg.toUserId === userId1)
-    ).sort((a, b) => a.timestamp - b.timestamp);
-  },
+
+  getMessagesForChat: (userId1, userId2, viewerId = null) =>
+    get()
+      .messages.filter(
+        (msg) =>
+          ((msg.fromUserId === userId1 && msg.toUserId === userId2) ||
+            (msg.fromUserId === userId2 && msg.toUserId === userId1)) &&
+          canReadEntity(viewerId, msg)
+      )
+      .sort((a, b) => a.timestamp - b.timestamp),
 }));

--- a/src/store/friendStore.ts
+++ b/src/store/friendStore.ts
@@ -1,72 +1,98 @@
 import { create } from 'zustand';
+import {
+  AccessControlledEntity,
+  Visibility,
+  canReadEntity,
+  resolveLayerIds,
+} from '../lib/permissions';
 
-interface FriendRequest {
+interface FriendRequest extends AccessControlledEntity {
   id: string;
   fromUserId: string;
   toUserId: string;
+  ownerId: string;
   status: 'pending' | 'accepted' | 'rejected';
+}
+
+interface SendFriendRequestInput {
+  fromUserId: string;
+  toUserId: string;
+  layerIds?: string[];
+  visibility?: Visibility;
 }
 
 interface FriendState {
   friendRequests: FriendRequest[];
-  sendFriendRequest: (fromUserId: string, toUserId: string) => void;
-  acceptFriendRequest: (requestId: string) => void;
-  rejectFriendRequest: (requestId: string) => void;
-  isFriend: (userId1: string, userId2: string) => boolean;
-  hasPendingRequest: (fromUserId: string, toUserId: string) => boolean;
+  sendFriendRequest: (input: SendFriendRequestInput) => void;
+  acceptFriendRequest: (requestId: string, actorId: string) => void;
+  rejectFriendRequest: (requestId: string, actorId: string) => void;
+  isFriend: (userId1: string, userId2: string, viewerId?: string | null) => boolean;
+  hasPendingRequest: (
+    fromUserId: string,
+    toUserId: string,
+    viewerId?: string | null
+  ) => boolean;
+  getVisibleRequests: (viewerId?: string | null) => FriendRequest[];
 }
 
 export const useFriendStore = create<FriendState>((set, get) => ({
   friendRequests: [],
-  
-  sendFriendRequest: (fromUserId, toUserId) => {
-    const newRequest: FriendRequest = {
-      id: Date.now().toString(),
+
+  sendFriendRequest: ({ fromUserId, toUserId, layerIds, visibility }) => {
+    const id = Date.now().toString();
+    const request: FriendRequest = {
+      id,
       fromUserId,
       toUserId,
+      ownerId: fromUserId,
       status: 'pending',
+      layerIds: resolveLayerIds(layerIds),
+      visibility: visibility ?? Visibility.MEMBERS,
     };
-    
+
     set((state) => ({
-      friendRequests: [...state.friendRequests, newRequest],
+      friendRequests: [...state.friendRequests, request],
     }));
   },
-  
-  acceptFriendRequest: (requestId) => {
+
+  acceptFriendRequest: (requestId, actorId) => {
     set((state) => ({
       friendRequests: state.friendRequests.map((request) =>
-        request.id === requestId
+        request.id === requestId && canReadEntity(actorId, request)
           ? { ...request, status: 'accepted' }
           : request
       ),
     }));
   },
-  
-  rejectFriendRequest: (requestId) => {
+
+  rejectFriendRequest: (requestId, actorId) => {
     set((state) => ({
       friendRequests: state.friendRequests.map((request) =>
-        request.id === requestId
+        request.id === requestId && canReadEntity(actorId, request)
           ? { ...request, status: 'rejected' }
           : request
       ),
     }));
   },
-  
-  isFriend: (userId1, userId2) => {
-    return get().friendRequests.some(
+
+  isFriend: (userId1, userId2, viewerId = null) =>
+    get().friendRequests.some(
       (request) =>
         request.status === 'accepted' &&
+        canReadEntity(viewerId, request) &&
         ((request.fromUserId === userId1 && request.toUserId === userId2) ||
-         (request.fromUserId === userId2 && request.toUserId === userId1))
-    );
-  },
-  
-  hasPendingRequest: (fromUserId, toUserId) => {
-    return get().friendRequests.some(
+          (request.fromUserId === userId2 && request.toUserId === userId1))
+    ),
+
+  hasPendingRequest: (fromUserId, toUserId, viewerId = null) =>
+    get().friendRequests.some(
       (request) =>
         request.status === 'pending' &&
+        canReadEntity(viewerId, request) &&
         request.fromUserId === fromUserId &&
         request.toUserId === toUserId
-    );
-  },
+    ),
+
+  getVisibleRequests: (viewerId = null) =>
+    get().friendRequests.filter((request) => canReadEntity(viewerId, request)),
 }));

--- a/src/store/layerStore.ts
+++ b/src/store/layerStore.ts
@@ -1,0 +1,245 @@
+import { create } from 'zustand';
+
+export interface Layer {
+  id: string;
+  name: string;
+  domain: string;
+  parentId: string | null;
+}
+
+export interface LayerMembershipSnapshot {
+  layerId: string;
+  userIds: string[];
+}
+
+interface LayerState {
+  layers: Record<string, Layer>;
+  domainRegistry: Record<string, string>;
+  memberships: Record<string, Set<string>>;
+  registerLayer: (layer: Omit<Layer, 'id'> & { id?: string }) => string;
+  removeLayer: (layerId: string) => void;
+  assignUserToLayer: (userId: string, layerId: string) => void;
+  removeUserFromLayer: (userId: string, layerId: string) => void;
+  getLayerById: (layerId: string) => Layer | undefined;
+  getLayerAncestors: (layerId: string) => string[];
+  getLayerDescendants: (layerId: string) => string[];
+  getUserResolvedLayers: (userId: string) => Set<string>;
+  userHasAccessToLayers: (userId: string, layerIds: string[]) => boolean;
+  ensureDomainLayer: (domain: string, options?: { name?: string; parentId?: string | null }) => string;
+  getLayersForDomain: (domain: string) => Layer[];
+  getMembershipSnapshot: () => LayerMembershipSnapshot[];
+  getDefaultLayerId: () => string;
+}
+
+export const ROOT_LAYER_ID = 'layer:root';
+const ROOT_LAYER_NAME = 'Global';
+const ROOT_DOMAIN = 'global';
+
+const createInitialState = () => {
+  const rootLayer: Layer = {
+    id: ROOT_LAYER_ID,
+    name: ROOT_LAYER_NAME,
+    domain: ROOT_DOMAIN,
+    parentId: null,
+  };
+
+  return {
+    layers: { [ROOT_LAYER_ID]: rootLayer },
+    domainRegistry: { [ROOT_DOMAIN]: ROOT_LAYER_ID },
+    memberships: { [ROOT_LAYER_ID]: new Set<string>() },
+  } satisfies Pick<LayerState, 'layers' | 'domainRegistry' | 'memberships'>;
+};
+
+export const useLayerStore = create<LayerState>((set, get) => ({
+  ...createInitialState(),
+
+  registerLayer: ({ id, name, domain, parentId }) => {
+    const layerId = id ?? `layer:${globalThis.crypto?.randomUUID?.() ?? Date.now().toString(36)}`;
+    const resolvedParentId = parentId ?? ROOT_LAYER_ID;
+
+    set((state) => {
+      if (!state.layers[resolvedParentId]) {
+        throw new Error(`Parent layer ${resolvedParentId} does not exist`);
+      }
+
+      const newLayer: Layer = {
+        id: layerId,
+        name,
+        domain,
+        parentId: resolvedParentId,
+      };
+
+      return {
+        layers: {
+          ...state.layers,
+          [layerId]: newLayer,
+        },
+        domainRegistry: {
+          ...state.domainRegistry,
+          [domain]: layerId,
+        },
+        memberships: {
+          ...state.memberships,
+          [layerId]: state.memberships[layerId] ?? new Set<string>(),
+        },
+      };
+    });
+
+    return layerId;
+  },
+
+  removeLayer: (layerId) => {
+    if (layerId === ROOT_LAYER_ID) {
+      throw new Error('The root layer cannot be removed');
+    }
+
+    set((state) => {
+      const { [layerId]: removedLayer, ...remainingLayers } = state.layers;
+      if (!removedLayer) {
+        return state;
+      }
+
+      const updatedDomainRegistry = Object.fromEntries(
+        Object.entries(state.domainRegistry).filter(([, id]) => id !== layerId)
+      );
+
+      const memberships = { ...state.memberships };
+      delete memberships[layerId];
+
+      Object.values(remainingLayers).forEach((layer) => {
+        if (layer.parentId === layerId) {
+          remainingLayers[layer.id] = { ...layer, parentId: removedLayer.parentId };
+        }
+      });
+
+      return {
+        layers: remainingLayers,
+        domainRegistry: updatedDomainRegistry,
+        memberships,
+      };
+    });
+  },
+
+  assignUserToLayer: (userId, layerId) => {
+    set((state) => {
+      const existing = state.memberships[layerId] ?? new Set<string>();
+      const next = new Set(existing);
+      next.add(userId);
+
+      return {
+        memberships: {
+          ...state.memberships,
+          [layerId]: next,
+        },
+      };
+    });
+  },
+
+  removeUserFromLayer: (userId, layerId) => {
+    set((state) => {
+      const existing = state.memberships[layerId];
+      if (!existing) {
+        return state;
+      }
+      const next = new Set(existing);
+      next.delete(userId);
+      return {
+        memberships: {
+          ...state.memberships,
+          [layerId]: next,
+        },
+      };
+    });
+  },
+
+  getLayerById: (layerId) => get().layers[layerId],
+
+  getLayerAncestors: (layerId) => {
+    const ancestors: string[] = [];
+    let current = get().layers[layerId];
+    while (current && current.parentId) {
+      ancestors.push(current.parentId);
+      current = get().layers[current.parentId];
+    }
+    return ancestors;
+  },
+
+  getLayerDescendants: (layerId) => {
+    const descendants: string[] = [];
+    const queue = [layerId];
+    const { layers } = get();
+
+    while (queue.length > 0) {
+      const currentId = queue.shift();
+      if (!currentId) continue;
+
+      Object.values(layers).forEach((layer) => {
+        if (layer.parentId === currentId) {
+          descendants.push(layer.id);
+          queue.push(layer.id);
+        }
+      });
+    }
+
+    return descendants;
+  },
+
+  getUserResolvedLayers: (userId) => {
+    const { memberships, getLayerAncestors } = get();
+    const resolved = new Set<string>();
+
+    Object.entries(memberships).forEach(([layerId, members]) => {
+      if (members.has(userId)) {
+        resolved.add(layerId);
+        getLayerAncestors(layerId).forEach((ancestorId) => resolved.add(ancestorId));
+      }
+    });
+
+    return resolved;
+  },
+
+  userHasAccessToLayers: (userId, layerIds) => {
+    if (layerIds.length === 0) {
+      return true;
+    }
+    const { getLayerAncestors, getUserResolvedLayers } = get();
+    const accessibleLayers = getUserResolvedLayers(userId);
+
+    return layerIds.some((layerId) => {
+      if (accessibleLayers.has(layerId)) {
+        return true;
+      }
+      const ancestors = getLayerAncestors(layerId);
+      return ancestors.some((ancestorId) => accessibleLayers.has(ancestorId));
+    });
+  },
+
+  ensureDomainLayer: (domain, options) => {
+    const existing = get().domainRegistry[domain];
+    if (existing) {
+      return existing;
+    }
+
+    return get().registerLayer({
+      id: undefined,
+      name: options?.name ?? domain,
+      domain,
+      parentId: options?.parentId ?? ROOT_LAYER_ID,
+    });
+  },
+
+  getLayersForDomain: (domain) => {
+    const { layers } = get();
+    return Object.values(layers).filter((layer) => layer.domain === domain);
+  },
+
+  getMembershipSnapshot: () => {
+    const { memberships } = get();
+    return Object.entries(memberships).map(([layerId, members]) => ({
+      layerId,
+      userIds: Array.from(members),
+    }));
+  },
+
+  getDefaultLayerId: () => ROOT_LAYER_ID,
+}));

--- a/src/store/storyStore.ts
+++ b/src/store/storyStore.ts
@@ -1,50 +1,76 @@
 import { create } from 'zustand';
+import {
+  AccessControlledEntity,
+  Visibility,
+  filterReadableEntities,
+  resolveLayerIds,
+} from '../lib/permissions';
 
-export interface Story {
+export interface Story extends AccessControlledEntity {
   id: string;
   userId: string;
+  ownerId: string;
   content: string;
   image?: string;
   createdAt: number;
-  expiresAt: number; // 24 hours after creation
+  expiresAt: number;
+}
+
+interface AddStoryInput {
+  userId: string;
+  content: string;
+  image?: string;
+  layerIds?: string[];
+  visibility?: Visibility;
 }
 
 interface StoryState {
   stories: Story[];
-  addStory: (userId: string, content: string, image?: string) => void;
+  addStory: (input: AddStoryInput) => void;
   removeStory: (storyId: string) => void;
-  getActiveStoriesForUser: (userId: string) => Story[];
+  getActiveStoriesForUser: (userId: string, viewerId?: string | null) => Story[];
+  getVisibleStories: (viewerId?: string | null) => Story[];
 }
 
 export const useStoryStore = create<StoryState>((set, get) => ({
   stories: [],
-  
-  addStory: (userId, content, image) => {
+
+  addStory: ({ userId, content, image, layerIds, visibility }) => {
     const now = Date.now();
-    const newStory: Story = {
+    const story: Story = {
       id: now.toString(),
       userId,
+      ownerId: userId,
       content,
       image,
       createdAt: now,
-      expiresAt: now + 24 * 60 * 60 * 1000, // 24 hours
+      expiresAt: now + 24 * 60 * 60 * 1000,
+      layerIds: resolveLayerIds(layerIds),
+      visibility: visibility ?? Visibility.MEMBERS,
     };
-    
+
     set((state) => ({
-      stories: [...state.stories, newStory],
+      stories: [...state.stories, story],
     }));
   },
-  
+
   removeStory: (storyId) => {
     set((state) => ({
       stories: state.stories.filter((story) => story.id !== storyId),
     }));
   },
-  
-  getActiveStoriesForUser: (userId) => {
+
+  getActiveStoriesForUser: (userId, viewerId = null) => {
     const now = Date.now();
-    return get().stories.filter(
+    const relevantStories = get().stories.filter(
       (story) => story.userId === userId && story.expiresAt > now
     );
+    return filterReadableEntities(viewerId, relevantStories);
+  },
+
+  getVisibleStories: (viewerId = null) => {
+    const now = Date.now();
+    const activeStories = get().stories.filter((story) => story.expiresAt > now);
+    return filterReadableEntities(viewerId, activeStories);
   },
 }));

--- a/src/store/userStore.ts
+++ b/src/store/userStore.ts
@@ -1,39 +1,108 @@
 import { create } from 'zustand';
+import {
+  AccessControlledEntity,
+  Visibility,
+  filterReadableEntities,
+  resolveLayerIds,
+} from '../lib/permissions';
+import { useLayerStore } from './layerStore';
 
-interface User {
+export interface PresenceUser extends AccessControlledEntity {
   id: string;
   name: string;
   color: string;
   online: boolean;
   lastSeen?: number;
   position?: [number, number, number];
+  profilePicture?: string;
+  bio?: string;
+  ownerId: string;
 }
 
+type NewUserPayload = Omit<
+  PresenceUser,
+  'online' | 'ownerId' | 'layerIds' | 'visibility'
+> &
+  Partial<Pick<PresenceUser, 'online' | 'layerIds' | 'visibility'>>;
+
 interface UserState {
-  users: User[];
+  users: PresenceUser[];
   onlineUsers: Set<string>;
-  addUser: (user: User) => void;
+  addUser: (user: NewUserPayload) => PresenceUser;
   removeUser: (userId: string) => void;
   setOnlineStatus: (userId: string, online: boolean) => void;
   updateUserPosition: (userId: string, position: [number, number, number]) => void;
   updateUserColor: (userId: string, color: string) => void;
-  getOnlineUsers: () => User[];
+  updateUserProfile: (
+    userId: string,
+    updates: Partial<Pick<PresenceUser, 'name' | 'profilePicture' | 'bio'>>
+  ) => void;
+  setUserLayers: (userId: string, layerIds: string[]) => void;
+  setUserVisibility: (userId: string, visibility: Visibility) => void;
+  getVisibleUsers: (viewerId?: string | null) => PresenceUser[];
+  getOnlineUsers: (viewerId?: string | null) => PresenceUser[];
+  getUserById: (userId: string) => PresenceUser | undefined;
 }
 
 export const useUserStore = create<UserState>((set, get) => ({
   users: [],
   onlineUsers: new Set<string>(),
 
-  addUser: (user) =>
-    set((state) => ({
-      users: state.users.filter(u => u.id !== user.id).concat({ ...user, online: false }),
-    })),
+  addUser: (userInput) => {
+    const existing = get().users.find((user) => user.id === userInput.id);
+    const { assignUserToLayer, removeUserFromLayer } = useLayerStore.getState();
 
-  removeUser: (userId) =>
+    if (existing) {
+      existing.layerIds.forEach((layerId) => removeUserFromLayer(existing.id, layerId));
+    }
+
+    const layerIds = resolveLayerIds(userInput.layerIds);
+    const presenceUser: PresenceUser = {
+      id: userInput.id,
+      name: userInput.name,
+      color: userInput.color,
+      position: userInput.position,
+      lastSeen: userInput.lastSeen,
+      profilePicture: userInput.profilePicture,
+      bio: userInput.bio,
+      online: userInput.online ?? false,
+      layerIds,
+      visibility: userInput.visibility ?? Visibility.MEMBERS,
+      ownerId: userInput.id,
+    };
+
+    set((state) => {
+      const filtered = state.users.filter((user) => user.id !== presenceUser.id);
+      const newOnlineUsers = new Set(state.onlineUsers);
+      if (presenceUser.online) {
+        newOnlineUsers.add(presenceUser.id);
+      } else {
+        newOnlineUsers.delete(presenceUser.id);
+      }
+
+      return {
+        users: [...filtered, presenceUser],
+        onlineUsers: newOnlineUsers,
+      };
+    });
+
+    layerIds.forEach((layerId) => assignUserToLayer(presenceUser.id, layerId));
+
+    return presenceUser;
+  },
+
+  removeUser: (userId) => {
+    const existing = get().users.find((user) => user.id === userId);
+    if (existing) {
+      const { removeUserFromLayer } = useLayerStore.getState();
+      existing.layerIds.forEach((layerId) => removeUserFromLayer(userId, layerId));
+    }
+
     set((state) => ({
       users: state.users.filter((user) => user.id !== userId),
-      onlineUsers: new Set([...state.onlineUsers].filter(id => id !== userId)),
-    })),
+      onlineUsers: new Set([...state.onlineUsers].filter((id) => id !== userId)),
+    }));
+  },
 
   setOnlineStatus: (userId, online) =>
     set((state) => {
@@ -68,8 +137,59 @@ export const useUserStore = create<UserState>((set, get) => ({
       ),
     })),
 
-  getOnlineUsers: () => {
-    const state = get();
-    return state.users.filter((user) => state.onlineUsers.has(user.id));
+  updateUserProfile: (userId, updates) =>
+    set((state) => ({
+      users: state.users.map((user) =>
+        user.id === userId ? { ...user, ...updates } : user
+      ),
+    })),
+
+  setUserLayers: (userId, layerIds) => {
+    const currentUser = get().users.find((user) => user.id === userId);
+    if (!currentUser) {
+      return;
+    }
+
+    const normalized = resolveLayerIds(layerIds);
+    const { assignUserToLayer, removeUserFromLayer } = useLayerStore.getState();
+
+    currentUser.layerIds
+      .filter((layerId) => !normalized.includes(layerId))
+      .forEach((layerId) => removeUserFromLayer(userId, layerId));
+
+    normalized
+      .filter((layerId) => !currentUser.layerIds.includes(layerId))
+      .forEach((layerId) => assignUserToLayer(userId, layerId));
+
+    set((state) => ({
+      users: state.users.map((user) =>
+        user.id === userId ? { ...user, layerIds: normalized } : user
+      ),
+    }));
   },
+
+  setUserVisibility: (userId, visibility) =>
+    set((state) => ({
+      users: state.users.map((user) =>
+        user.id === userId ? { ...user, visibility } : user
+      ),
+    })),
+
+  getVisibleUsers: (viewerId = null) => {
+    const state = get();
+    return filterReadableEntities(viewerId, state.users);
+  },
+
+  getOnlineUsers: (viewerId = null) => {
+    const state = get();
+    const visibleUserIds = new Set(
+      state.getVisibleUsers(viewerId).map((user) => user.id)
+    );
+
+    return state.users.filter(
+      (user) => visibleUserIds.has(user.id) && state.onlineUsers.has(user.id)
+    );
+  },
+
+  getUserById: (userId) => get().users.find((user) => user.id === userId),
 }));


### PR DESCRIPTION
## Summary
- add a dedicated layer store for hierarchical domains and memberships
- introduce shared permission utilities and extend data stores with visibility-aware records
- update UI components to consume permission-filtered selectors for user, chat, story, and request data

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e2b680cd5483239dd460282fc05847