### PR TITLE
refactor: balance workspace layout controls

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,97 @@
-# unworld3.0
+# unworld3.0 — Enclypse Workspace
 
-[Edit in StackBlitz next generation editor ⚡️](https://stackblitz.com/~/github.com/RepertoireLLC/unworld3.0)
+Enclypse is an encrypted, presence-aware collaboration environment designed around modular operator tooling. This workspace edition adds a configurable control deck where encrypted vaults, privacy templates, and audit telemetry can be orchestrated without leaving the primary console.
+
+## ✨ Feature Highlights
+
+- **Workspace Panel** – A modular grid that persists layout, widget sizing, and collapse state locally for every operator session.
+- **Encrypted File Vault** – Client-side AES-GCM encryption with permission-aware download gating and per-file activity logging.
+- **Widget Management Library** – Activate, remove, resize, and focus workspace widgets with a resettable registry.
+- **Privacy Template Presets** – Apply curated permission blueprints (solo lockdown, ops sync, broadcast audit, live online cohort) to vault assets or workspace modules.
+- **Activity & Permission Log** – Filterable audit trail capturing uploads, download attempts, permission grants, and template deployments.
+- **Header Quick Actions** – One-click navigation chips to focus vault, privacy, layout, or audit widgets from anywhere in the console.
+
+## 🧱 Architecture Overview
+
+- **Front-end**: React + TypeScript, styled with TailwindCSS and Lucide icons. State orchestration uses Zustand stores with local persistence.
+- **Encryption**: Browser-native Web Crypto API (AES-GCM) powers file encryption/decryption through a shared `encryptionService`.
+- **Storage**: Encrypted payloads, workspace layout, permissions, and audit trails persist in browser storage (via Zustand `persist`).
+- **Permissions**: A dedicated permission service shares rule evaluation and templates across the vault, templates widget, and activity log.
+- **Logging**: Activity store centralizes success/warning/error events for visibility across widgets.
+
+## 🚀 Getting Started
+
+1. **Install dependencies**
+   ```bash
+   npm install
+   ```
+
+2. **Run the Vite development server**
+   ```bash
+   npm run dev
+   ```
+
+3. **Open the console**
+   Navigate to the printed localhost URL and authenticate (register/login) to unlock the workspace. Layout state and vault entries are persisted per browser profile.
+
+## ⚙️ Configuration
+
+| Variable | Purpose | Default |
+| --- | --- | --- |
+| `VITE_VAULT_DEFAULT_KEY` | Optional default encryption passphrase pre-filled in the encrypted vault widget. Useful for provisioning shared demo environments. | _empty_ |
+
+### Storage adapters
+
+The workspace uses the built-in Zustand `persist` middleware which targets `localStorage`. For environments that require alternate persistence (e.g., IndexedDB or cloud sync), replace the storage adapter in:
+
+- `src/store/workspaceStore.ts`
+- `src/store/vaultStore.ts`
+- `src/store/permissionStore.ts`
+- `src/store/activityLogStore.ts`
+
+Each file exposes a single `persist` configuration block that can be swapped with custom storage drivers. Ensure the replacement adapter conforms to the standard Storage API (`getItem`, `setItem`, `removeItem`).
+
+### Encryption keys
+
+- Operators must supply a strong passphrase per upload/download cycle. Keys are never stored.
+- AES-GCM encryption happens entirely client-side; losing the passphrase renders the payload unrecoverable.
+- Set `VITE_VAULT_DEFAULT_KEY` during development to streamline repeated testing. Do **not** ship shared keys in production builds.
+
+## 🧭 Using the Workspace
+
+1. **Manage layout**: Use the workspace drop-downs (arrangement, density, and category) or the widget management block to toggle modules, adjust widths, or reset the grid.
+2. **Secure files**: Use the encrypted vault widget to upload files (encrypted at rest) and download them with the correct passphrase. Permission badges display the current access graph.
+3. **Apply templates**: Select a vault asset (or the workspace module) and push a privacy preset to rewrite the permission matrix instantly.
+4. **Audit activity**: Monitor successful uploads, blocked downloads, and permission changes via the activity log. Filter by severity to triage faster.
+
+## 🛡️ Security Notes
+
+- AES-GCM with a SHA-256 derived key is used for all vault payloads.
+- Permission enforcement runs before decrypting any payload, reducing unnecessary crypto operations for unauthorized attempts.
+- Activity logging captures both successful and failed access events to maintain an audit trail.
+
+## 📁 Key Directories
+
+```
+src/
+├─ components/
+│  └─ interface/
+│     ├─ WorkspacePanel.tsx
+│     └─ workspace/
+│        └─ widgets/
+├─ services/
+│  ├─ encryptionService.ts
+│  └─ permissionService.ts
+└─ store/
+   ├─ activityLogStore.ts
+   ├─ permissionStore.ts
+   ├─ vaultStore.ts
+   └─ workspaceStore.ts
+```
+
+## ✅ Next Steps
+
+- Integrate backend storage adapters (S3, PostgreSQL, etc.) by replacing the Zustand persist targets.
+- Extend permission templates with role-based policies sourced from the authentication service.
+- Wire real-time presence events into the workspace so template rules can react instantly to operator changes.
+

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -9,7 +9,7 @@ import { initializeMockData } from './store/mockData';
 import { useThemeStore } from './store/themeStore';
 import { HeaderBar } from './components/interface/HeaderBar';
 import { ControlPanel } from './components/interface/ControlPanel';
-import { BroadcastPanel } from './components/interface/BroadcastPanel';
+import { WorkspacePanel } from './components/interface/WorkspacePanel';
 import { FieldNotesPanel } from './components/interface/FieldNotesPanel';
 
 export function App() {
@@ -53,7 +53,7 @@ export function App() {
 
           <main className="grid flex-1 gap-6 lg:grid-cols-[320px_minmax(0,1fr)_320px] xl:grid-cols-[340px_minmax(0,1fr)_340px]">
             <ControlPanel />
-            <BroadcastPanel />
+            <WorkspacePanel />
             <FieldNotesPanel />
           </main>
 

--- a/src/components/interface/HeaderBar.tsx
+++ b/src/components/interface/HeaderBar.tsx
@@ -4,10 +4,13 @@ import { ThemeSelector } from '../ThemeSelector';
 import { ProfileIcon } from '../ProfileIcon';
 import { useAuthStore } from '../../store/authStore';
 import { useThemeStore } from '../../store/themeStore';
+import { useWorkspaceStore } from '../../store/workspaceStore';
+import { ChevronDown, KeyRound, LayoutDashboard, ScrollText, ShieldCheck } from 'lucide-react';
 
 export function HeaderBar() {
   const currentUser = useAuthStore((state) => state.user);
   const currentTheme = useThemeStore((state) => state.currentTheme);
+  const focusWidget = useWorkspaceStore((state) => state.focusWidget);
 
   return (
     <header className="flex flex-col gap-4 lg:flex-row lg:items-center lg:justify-between">
@@ -23,6 +26,54 @@ export function HeaderBar() {
             Linked operator: <span className="text-white">{currentUser.name}</span> · Theme vector: <span className="uppercase tracking-[0.2em] text-white/50">{currentTheme}</span>
           </p>
         )}
+        <details className="group mt-3 w-full max-w-xs rounded-2xl border border-white/10 bg-white/5 p-3 text-[11px] uppercase tracking-[0.3em] text-white/50">
+          <summary className="flex cursor-pointer items-center justify-between gap-2 text-white/60">
+            Workspace Quick Actions
+            <ChevronDown className="h-3.5 w-3.5 transition group-open:rotate-180" />
+          </summary>
+          <div className="mt-3 grid gap-2 text-[11px]">
+            <button
+              type="button"
+              onClick={() => focusWidget('encryptedVault')}
+              className="flex items-center justify-between gap-2 rounded-xl border border-emerald-400/40 bg-emerald-500/10 px-3 py-2 text-emerald-200 transition hover:bg-emerald-500/20"
+            >
+              <span className="flex items-center gap-2">
+                <KeyRound className="h-3.5 w-3.5" /> Encrypted Vault
+              </span>
+              Focus
+            </button>
+            <button
+              type="button"
+              onClick={() => focusWidget('privacyTemplates')}
+              className="flex items-center justify-between gap-2 rounded-xl border border-sky-400/40 bg-sky-500/10 px-3 py-2 text-sky-200 transition hover:bg-sky-500/20"
+            >
+              <span className="flex items-center gap-2">
+                <ShieldCheck className="h-3.5 w-3.5" /> Privacy Presets
+              </span>
+              Focus
+            </button>
+            <button
+              type="button"
+              onClick={() => focusWidget('widgetManager')}
+              className="flex items-center justify-between gap-2 rounded-xl border border-white/10 bg-white/10 px-3 py-2 text-white/70 transition hover:bg-white/20"
+            >
+              <span className="flex items-center gap-2">
+                <LayoutDashboard className="h-3.5 w-3.5" /> Widget Manager
+              </span>
+              Focus
+            </button>
+            <button
+              type="button"
+              onClick={() => focusWidget('activityLog')}
+              className="flex items-center justify-between gap-2 rounded-xl border border-fuchsia-400/40 bg-fuchsia-500/10 px-3 py-2 text-fuchsia-200 transition hover:bg-fuchsia-500/20"
+            >
+              <span className="flex items-center gap-2">
+                <ScrollText className="h-3.5 w-3.5" /> Audit Log
+              </span>
+              Focus
+            </button>
+          </div>
+        </details>
       </div>
 
       <div className="flex w-full flex-col gap-3 lg:w-auto lg:flex-row lg:items-center lg:justify-end">

--- a/src/components/interface/WorkspacePanel.tsx
+++ b/src/components/interface/WorkspacePanel.tsx
@@ -1,0 +1,276 @@
+import { useEffect, useMemo } from 'react';
+import {
+  ChevronDown,
+  ChevronUp,
+  Filter,
+  LayoutGrid,
+  Maximize2,
+  Minimize2,
+  SlidersHorizontal,
+} from 'lucide-react';
+import {
+  useWorkspaceStore,
+  WorkspaceArrangement,
+  WorkspaceDensity,
+  WorkspaceWidgetKey,
+  WorkspaceWidgetCategory,
+} from '../../store/workspaceStore';
+import { EncryptedVaultWidget } from './workspace/widgets/EncryptedVaultWidget';
+import { WidgetManagementWidget } from './workspace/widgets/WidgetManagementWidget';
+import { PrivacyTemplatesWidget } from './workspace/widgets/PrivacyTemplatesWidget';
+import { ActivityLogWidget } from './workspace/widgets/ActivityLogWidget';
+
+const widgetComponents: Record<WorkspaceWidgetKey, React.FC<{ widgetId: WorkspaceWidgetKey }>> = {
+  encryptedVault: EncryptedVaultWidget,
+  widgetManager: WidgetManagementWidget,
+  privacyTemplates: PrivacyTemplatesWidget,
+  activityLog: ActivityLogWidget,
+};
+
+export function WorkspacePanel() {
+  const layout = useWorkspaceStore((state) => state.layout);
+  const registry = useWorkspaceStore((state) => state.registry);
+  const minimized = useWorkspaceStore((state) => state.minimized);
+  const preferences = useWorkspaceStore((state) => state.preferences);
+  const moveWidget = useWorkspaceStore((state) => state.moveWidget);
+  const toggleCollapse = useWorkspaceStore((state) => state.toggleCollapse);
+  const removeWidget = useWorkspaceStore((state) => state.removeWidget);
+  const focusedWidget = useWorkspaceStore((state) => state.focusedWidget);
+  const clearFocus = useWorkspaceStore((state) => state.clearFocus);
+  const layoutDensity = useWorkspaceStore((state) => state.layoutDensity);
+  const setLayoutDensity = useWorkspaceStore((state) => state.setLayoutDensity);
+  const arrangement = useWorkspaceStore((state) => state.arrangement);
+  const setArrangement = useWorkspaceStore((state) => state.setArrangement);
+  const activeCategory = useWorkspaceStore((state) => state.activeCategory);
+  const setActiveCategory = useWorkspaceStore((state) => state.setActiveCategory);
+
+  const densityOptions: Array<{ label: string; value: WorkspaceDensity; description: string }> = [
+    { value: 'compact', label: 'Compact', description: 'Tighter spacing · more widgets per viewport' },
+    { value: 'balanced', label: 'Balanced', description: 'Even column rhythm for daily operations' },
+    { value: 'spacious', label: 'Spacious', description: 'Breathing room for focus-intensive reviews' },
+  ];
+
+  const arrangementOptions: Array<{ label: string; value: WorkspaceArrangement; description: string }> = [
+    { value: 'manual', label: 'Manual', description: 'Respect custom ordering' },
+    { value: 'alphabetical', label: 'Alphabetical', description: 'A → Z by module name' },
+    { value: 'category', label: 'Category', description: 'Group by security, governance, ops' },
+  ];
+
+  const categoryFilters: Array<{ label: string; value: 'all' | WorkspaceWidgetCategory }> = [
+    { value: 'all', label: 'All modules' },
+    { value: 'security', label: 'Security' },
+    { value: 'governance', label: 'Governance' },
+    { value: 'operations', label: 'Operations' },
+  ];
+
+  const categoryLabels: Record<WorkspaceWidgetCategory, string> = {
+    security: 'Security',
+    governance: 'Governance',
+    operations: 'Operations',
+  };
+
+  const gridDensityClass: Record<WorkspaceDensity, string> = {
+    compact: 'grid-cols-1 gap-4 xl:grid-cols-12 xl:auto-rows-[minmax(220px,_auto)]',
+    balanced: 'grid-cols-1 gap-5 xl:grid-cols-12 xl:auto-rows-[minmax(260px,_auto)]',
+    spacious: 'grid-cols-1 gap-6 xl:grid-cols-12 xl:auto-rows-[minmax(320px,_auto)]',
+  };
+
+  const orderedLayout = useMemo(() => {
+    const activeWidgets = layout.filter((widgetId) => Boolean(registry[widgetId]));
+    const filteredWidgets =
+      activeCategory === 'all'
+        ? activeWidgets
+        : activeWidgets.filter((widgetId) => registry[widgetId]?.category === activeCategory);
+
+    if (arrangement === 'manual') {
+      return filteredWidgets;
+    }
+
+    const sortedWidgets = [...filteredWidgets];
+    if (arrangement === 'alphabetical') {
+      sortedWidgets.sort((a, b) => registry[a].title.localeCompare(registry[b].title));
+    } else if (arrangement === 'category') {
+      const categoryOrder: WorkspaceWidgetCategory[] = ['security', 'governance', 'operations'];
+      sortedWidgets.sort((a, b) => {
+        const categoryRank = (key: WorkspaceWidgetKey) =>
+          categoryOrder.indexOf(registry[key].category as WorkspaceWidgetCategory);
+        const rankDiff = categoryRank(a) - categoryRank(b);
+        if (rankDiff !== 0) return rankDiff;
+        return registry[a].title.localeCompare(registry[b].title);
+      });
+    }
+    return sortedWidgets;
+  }, [layout, registry, arrangement, activeCategory]);
+
+  useEffect(() => {
+    if (!focusedWidget) return;
+    const timeout = setTimeout(() => clearFocus(), 3200);
+    return () => clearTimeout(timeout);
+  }, [focusedWidget, clearFocus]);
+
+  return (
+    <section className="flex h-full flex-col gap-6 rounded-3xl border border-white/10 bg-white/5 p-6 shadow-[0_30px_80px_-40px_rgba(15,23,42,0.9)]">
+      <header className="flex flex-col gap-2">
+        <div className="flex flex-col gap-3 lg:flex-row lg:items-start lg:justify-between">
+          <div className="space-y-1">
+            <p className="text-xs uppercase tracking-[0.3em] text-white/50">Workspace Deck</p>
+            <h2 className="text-2xl font-semibold text-white">Operator Workspace</h2>
+            <p className="max-w-2xl text-sm text-white/60">
+              Tailor encrypted tooling blocks to match your mission rhythm. Arrangement, density, and categories persist to your local graph.
+            </p>
+          </div>
+          <div className="flex flex-col gap-2 rounded-2xl border border-white/10 bg-slate-950/70 p-4 text-xs uppercase tracking-[0.3em] text-white/50 shadow-inner">
+            <span className="flex items-center gap-2 text-white/60">
+              <LayoutGrid className="h-4 w-4 text-emerald-300" />
+              {orderedLayout.length} active module{orderedLayout.length === 1 ? '' : 's'} · {layout.length} pinned
+            </span>
+            <span className="text-[11px] text-white/40">
+              Focused module resets after {focusedWidget ? 'a short burst' : 'each session'} for a consistent cadence.
+            </span>
+          </div>
+        </div>
+        <div className="mt-4 flex flex-col gap-3 xl:flex-row xl:items-center xl:justify-between">
+          <div className="flex flex-wrap items-center gap-2 text-[11px] uppercase tracking-[0.3em] text-white/50">
+            <span className="text-white/40">Layout controls:</span>
+            <label className="flex items-center gap-2 rounded-full border border-white/10 bg-white/5 px-3 py-1 text-white/60">
+              <SlidersHorizontal className="h-3.5 w-3.5 text-emerald-300" />
+              <span className="sr-only">Arrangement</span>
+              <select
+                className="bg-transparent text-[11px] uppercase tracking-[0.3em] text-white/70 focus:outline-none"
+                value={arrangement}
+                onChange={(event) => setArrangement(event.target.value as WorkspaceArrangement)}
+              >
+                {arrangementOptions.map((option) => (
+                  <option key={option.value} value={option.value} className="bg-slate-900 text-white">
+                    {option.label}
+                  </option>
+                ))}
+              </select>
+            </label>
+            <label className="flex items-center gap-2 rounded-full border border-white/10 bg-white/5 px-3 py-1 text-white/60">
+              <LayoutGrid className="h-3.5 w-3.5 text-sky-300" />
+              <span className="sr-only">Density</span>
+              <select
+                className="bg-transparent text-[11px] uppercase tracking-[0.3em] text-white/70 focus:outline-none"
+                value={layoutDensity}
+                onChange={(event) => setLayoutDensity(event.target.value as WorkspaceDensity)}
+              >
+                {densityOptions.map((option) => (
+                  <option key={option.value} value={option.value} className="bg-slate-900 text-white">
+                    {option.label}
+                  </option>
+                ))}
+              </select>
+            </label>
+            <label className="flex items-center gap-2 rounded-full border border-white/10 bg-white/5 px-3 py-1 text-white/60">
+              <Filter className="h-3.5 w-3.5 text-fuchsia-300" />
+              <span className="sr-only">Category Filter</span>
+              <select
+                className="bg-transparent text-[11px] uppercase tracking-[0.3em] text-white/70 focus:outline-none"
+                value={activeCategory}
+                onChange={(event) => setActiveCategory(event.target.value as 'all' | WorkspaceWidgetCategory)}
+              >
+                {categoryFilters.map((option) => (
+                  <option key={option.value} value={option.value} className="bg-slate-900 text-white">
+                    {option.label}
+                  </option>
+                ))}
+              </select>
+            </label>
+          </div>
+          <div className="grid gap-1 text-[11px] text-white/40">
+            <p>
+              <strong className="text-white/70">{densityOptions.find((item) => item.value === layoutDensity)?.label}</strong> ·{' '}
+              {densityOptions.find((item) => item.value === layoutDensity)?.description}
+            </p>
+            <p>
+              <strong className="text-white/70">{arrangementOptions.find((item) => item.value === arrangement)?.label}</strong> ·{' '}
+              {arrangementOptions.find((item) => item.value === arrangement)?.description}
+            </p>
+          </div>
+        </div>
+      </header>
+
+      <div className={`grid flex-1 ${gridDensityClass[layoutDensity]}`}>
+        {orderedLayout.map((widgetId, index) => {
+          const widget = registry[widgetId];
+          if (!widget) return null;
+          const WidgetComponent = widgetComponents[widgetId];
+          if (!WidgetComponent) return null;
+          const preference = preferences[widgetId];
+          const size = preference?.size ?? widget.defaultSize;
+          const spanClass = size === 'full' ? 'xl:col-span-12' : 'xl:col-span-6';
+          const isMinimized = minimized[widgetId];
+          const isFocused = focusedWidget === widgetId;
+
+          return (
+            <article
+              key={widgetId}
+              className={`relative flex flex-col overflow-hidden rounded-3xl border border-white/10 bg-slate-950/60 transition focus-within:ring-2 focus-within:ring-emerald-500/50 ${spanClass} ${
+                isFocused ? 'ring-2 ring-emerald-400/80' : ''
+              }`}
+            >
+              <div className="flex items-start justify-between gap-3 border-b border-white/10 bg-white/5 px-5 py-4">
+                <div className="space-y-1">
+                  <span className="inline-flex items-center gap-2 rounded-full border border-white/10 bg-white/5 px-3 py-1 text-[10px] uppercase tracking-[0.3em] text-white/50">
+                    {categoryLabels[widget.category]}
+                  </span>
+                  <div>
+                    <h3 className="text-lg font-semibold text-white">{widget.title}</h3>
+                    <p className="text-xs text-white/50">{widget.description}</p>
+                  </div>
+                </div>
+                <div className="flex items-center gap-2">
+                  <button
+                    type="button"
+                    onClick={() => moveWidget(widgetId, 'up')}
+                    disabled={index === 0}
+                    className="rounded-lg border border-white/10 bg-white/10 p-2 text-white/60 transition hover:bg-white/20 disabled:cursor-not-allowed disabled:text-white/30"
+                  >
+                    <ChevronUp className="h-4 w-4" />
+                  </button>
+                  <button
+                    type="button"
+                    onClick={() => moveWidget(widgetId, 'down')}
+                    disabled={index === layout.length - 1}
+                    className="rounded-lg border border-white/10 bg-white/10 p-2 text-white/60 transition hover:bg-white/20 disabled:cursor-not-allowed disabled:text-white/30"
+                  >
+                    <ChevronDown className="h-4 w-4" />
+                  </button>
+                  <button
+                    type="button"
+                    onClick={() => toggleCollapse(widgetId)}
+                    className="rounded-lg border border-white/10 bg-white/10 p-2 text-white/60 transition hover:bg-white/20"
+                  >
+                    {isMinimized ? <Maximize2 className="h-4 w-4" /> : <Minimize2 className="h-4 w-4" />}
+                  </button>
+                  <button
+                    type="button"
+                    onClick={() => removeWidget(widgetId)}
+                    className="rounded-lg border border-rose-400/40 bg-rose-500/10 p-2 text-rose-200 transition hover:bg-rose-500/20"
+                    aria-label={`Remove ${widget.title}`}
+                  >
+                    ✕
+                  </button>
+                </div>
+              </div>
+
+              {!isMinimized && (
+                <div className="flex-1 overflow-hidden">
+                  <WidgetComponent widgetId={widgetId} />
+                </div>
+              )}
+            </article>
+          );
+        })}
+
+        {orderedLayout.length === 0 && (
+          <div className="col-span-full flex h-full flex-col items-center justify-center gap-3 rounded-3xl border border-dashed border-white/20 bg-white/5 p-10 text-center">
+            <p className="text-sm uppercase tracking-[0.3em] text-white/50">No active widgets</p>
+            <p className="text-base text-white/70">Use the widget management panel to activate workspace modules.</p>
+          </div>
+        )}
+      </div>
+    </section>
+  );
+}

--- a/src/components/interface/workspace/widgets/ActivityLogWidget.tsx
+++ b/src/components/interface/workspace/widgets/ActivityLogWidget.tsx
@@ -1,0 +1,99 @@
+import type { JSX } from 'react';
+import { useMemo, useState } from 'react';
+import { AlertTriangle, CheckCircle2, Clock3, Filter, Trash2 } from 'lucide-react';
+import { useActivityLogStore, ActivityStatus } from '../../../../store/activityLogStore';
+
+interface WidgetProps {
+  widgetId: string;
+}
+
+const statusStyles: Record<ActivityStatus, string> = {
+  success: 'border-emerald-400/40 bg-emerald-500/10 text-emerald-200',
+  warning: 'border-amber-400/40 bg-amber-500/10 text-amber-200',
+  error: 'border-rose-400/40 bg-rose-500/10 text-rose-200',
+};
+
+const statusIcons: Record<ActivityStatus, JSX.Element> = {
+  success: <CheckCircle2 className="h-4 w-4" />,
+  warning: <AlertTriangle className="h-4 w-4" />,
+  error: <AlertTriangle className="h-4 w-4" />,
+};
+
+function formatTimestamp(timestamp: number) {
+  return new Date(timestamp).toLocaleTimeString([], { hour: '2-digit', minute: '2-digit', second: '2-digit' });
+}
+
+export function ActivityLogWidget({ widgetId: _widgetId }: WidgetProps) {
+  const entries = useActivityLogStore((state) => state.entries);
+  const clearLog = useActivityLogStore((state) => state.clearLog);
+  const [filter, setFilter] = useState<ActivityStatus | 'all'>('all');
+
+  const filteredEntries = useMemo(() => {
+    if (filter === 'all') return entries;
+    return entries.filter((entry) => entry.status === filter);
+  }, [entries, filter]);
+
+  return (
+    <div className="flex h-full flex-col gap-4 p-5">
+      <div className="flex items-center justify-between">
+        <div>
+          <p className="text-xs uppercase tracking-[0.3em] text-white/50">Audit Feed</p>
+          <h4 className="text-lg font-semibold text-white">Activity & Permission Log</h4>
+        </div>
+        <button
+          type="button"
+          onClick={clearLog}
+          className="flex items-center gap-2 rounded-xl border border-white/10 bg-white/10 px-3 py-2 text-xs uppercase tracking-[0.3em] text-white/60 transition hover:bg-white/20"
+        >
+          <Trash2 className="h-4 w-4" /> Clear
+        </button>
+      </div>
+
+      <div className="flex items-center gap-2 text-xs uppercase tracking-[0.3em] text-white/50">
+        <Filter className="h-4 w-4 text-white/40" />
+        <select
+          value={filter}
+          onChange={(event) => setFilter(event.target.value as ActivityStatus | 'all')}
+          className="rounded-lg border border-white/10 bg-white/5 px-3 py-2 text-xs text-white focus:border-white/30 focus:outline-none"
+        >
+          <option value="all">All Events</option>
+          <option value="success">Success</option>
+          <option value="warning">Warnings</option>
+          <option value="error">Errors</option>
+        </select>
+      </div>
+
+      <div className="flex-1 overflow-y-auto">
+        {filteredEntries.length === 0 ? (
+          <div className="rounded-2xl border border-white/10 bg-white/5 p-6 text-center text-sm text-white/60">
+            No events recorded yet.
+          </div>
+        ) : (
+          <ul className="space-y-3">
+            {filteredEntries.map((entry) => (
+              <li
+                key={entry.id}
+                className={`rounded-2xl border px-4 py-3 text-sm ${statusStyles[entry.status]}`}
+              >
+                <div className="flex items-center justify-between text-xs uppercase tracking-[0.3em]">
+                  <span className="flex items-center gap-2 text-white/70">
+                    {statusIcons[entry.status]}
+                    {entry.action.replaceAll('_', ' ')}
+                  </span>
+                  <span className="flex items-center gap-1 text-white/60">
+                    <Clock3 className="h-4 w-4" />
+                    {formatTimestamp(entry.timestamp)}
+                  </span>
+                </div>
+                <p className="mt-2 text-xs text-white/80">{entry.message}</p>
+                {entry.resourceId && (
+                  <p className="mt-1 text-[11px] uppercase tracking-[0.3em] text-white/50">Resource: {entry.resourceId}</p>
+                )}
+              </li>
+            ))}
+          </ul>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/components/interface/workspace/widgets/EncryptedVaultWidget.tsx
+++ b/src/components/interface/workspace/widgets/EncryptedVaultWidget.tsx
@@ -1,0 +1,188 @@
+import { FormEvent, useMemo, useState } from 'react';
+import { DownloadCloud, KeyRound, ShieldCheck, UploadCloud } from 'lucide-react';
+import { useVaultStore } from '../../../../store/vaultStore';
+import { usePermissionStore } from '../../../../store/permissionStore';
+import { useAuthStore } from '../../../../store/authStore';
+
+interface WidgetProps {
+  widgetId: string;
+}
+
+export function EncryptedVaultWidget({ widgetId }: WidgetProps) {
+  const files = useVaultStore((state) => state.files);
+  const uploadFile = useVaultStore((state) => state.uploadFile);
+  const requestDownload = useVaultStore((state) => state.requestDownload);
+  const getPermissionsForResource = usePermissionStore((state) => state.getPermissionsForResource);
+  const ensureResource = usePermissionStore((state) => state.ensureResource);
+  const currentUser = useAuthStore((state) => state.user);
+
+  const defaultKey = useMemo(() => import.meta.env.VITE_VAULT_DEFAULT_KEY ?? '', []);
+  const [selectedFile, setSelectedFile] = useState<File | null>(null);
+  const [encryptionKey, setEncryptionKey] = useState(defaultKey);
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const [feedback, setFeedback] = useState<string | null>(null);
+  const [downloadKeys, setDownloadKeys] = useState<Record<string, string>>({});
+
+  const handleSubmit = async (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    if (!selectedFile) {
+      setFeedback('Select a file to encrypt and upload.');
+      return;
+    }
+    setIsSubmitting(true);
+    const response = await uploadFile(selectedFile, encryptionKey.trim());
+    setIsSubmitting(false);
+    setFeedback(response.message);
+    if (response.success) {
+      setSelectedFile(null);
+      ensureResource(widgetId, 'workspace-widget', currentUser?.id ?? 'system');
+    }
+  };
+
+  const handleDownload = async (fileId: string) => {
+    const key = downloadKeys[fileId] ?? encryptionKey;
+    if (!key) {
+      setFeedback('Provide an encryption key to decrypt the file.');
+      return;
+    }
+    const response = await requestDownload(fileId, key.trim());
+    if (!response.success) {
+      setFeedback(response.message);
+      return;
+    }
+
+    const anchor = document.createElement('a');
+    anchor.href = response.objectUrl;
+    anchor.download = response.fileName;
+    anchor.click();
+    URL.revokeObjectURL(response.objectUrl);
+    setFeedback(`Downloaded ${response.fileName}.`);
+  };
+
+  return (
+    <div className="flex h-full flex-col">
+      <form
+        onSubmit={handleSubmit}
+        className="rounded-3xl border-b border-white/10 bg-white/5 p-5"
+      >
+        <div className="flex flex-col gap-4 md:flex-row md:items-end">
+          <div className="flex-1">
+            <label className="flex items-center gap-2 text-xs uppercase tracking-[0.3em] text-white/50">
+              <UploadCloud className="h-4 w-4 text-emerald-300" />
+              Secure Upload Capsule
+            </label>
+            <input
+              type="file"
+              onChange={(event) => setSelectedFile(event.target.files?.[0] ?? null)}
+              className="mt-2 w-full cursor-pointer rounded-xl border border-white/10 bg-slate-950/60 px-4 py-3 text-sm text-white file:mr-4 file:rounded-lg file:border-0 file:bg-emerald-500/20 file:px-3 file:py-2 file:text-emerald-200"
+            />
+          </div>
+          <div className="md:w-64">
+            <label className="flex items-center gap-2 text-xs uppercase tracking-[0.3em] text-white/50">
+              <KeyRound className="h-4 w-4 text-sky-300" />
+              Encryption Key
+            </label>
+            <input
+              type="password"
+              value={encryptionKey}
+              onChange={(event) => setEncryptionKey(event.target.value)}
+              placeholder="Enter strong key"
+              className="mt-2 w-full rounded-xl border border-white/10 bg-slate-950/60 px-4 py-3 text-sm text-white placeholder:text-white/40 focus:border-white/30 focus:outline-none"
+            />
+          </div>
+          <button
+            type="submit"
+            disabled={isSubmitting}
+            className="md:w-auto rounded-xl border border-emerald-400/40 bg-emerald-500/10 px-4 py-3 text-xs uppercase tracking-[0.3em] text-emerald-300 transition hover:bg-emerald-500/20 disabled:cursor-not-allowed disabled:border-white/10 disabled:bg-white/5 disabled:text-white/40"
+          >
+            {isSubmitting ? 'Encrypting…' : 'Encrypt & Store'}
+          </button>
+        </div>
+        {feedback && <p className="mt-3 text-xs text-white/50">{feedback}</p>}
+      </form>
+
+      <div className="flex-1 overflow-y-auto px-5 py-4">
+        <div className="flex items-center justify-between text-xs uppercase tracking-[0.3em] text-white/50">
+          <span>Encrypted Capsules</span>
+          <span className="rounded-full border border-white/10 px-3 py-1 text-white/60">{files.length} Stored</span>
+        </div>
+
+        <div className="mt-4 space-y-4">
+          {files.length === 0 && (
+            <div className="rounded-2xl border border-white/10 bg-white/5 p-6 text-center text-sm text-white/60">
+              No encrypted files yet. Upload artifacts to populate the vault.
+            </div>
+          )}
+
+          {files.map((file) => {
+            const permissions = getPermissionsForResource(file.id);
+            return (
+              <div
+                key={file.id}
+                className="rounded-2xl border border-white/10 bg-slate-950/60 p-4"
+              >
+                <div className="flex flex-wrap items-center justify-between gap-3">
+                  <div>
+                    <p className="text-sm font-medium text-white">{file.name}</p>
+                    <p className="text-xs text-white/40">
+                      {(file.size / 1024).toFixed(1)} KB · Uploaded {new Date(file.uploadedAt).toLocaleString()}
+                    </p>
+                  </div>
+                  <button
+                    type="button"
+                    onClick={() => handleDownload(file.id)}
+                    className="flex items-center gap-2 rounded-lg border border-sky-400/40 bg-sky-500/10 px-3 py-2 text-xs uppercase tracking-[0.3em] text-sky-200 transition hover:bg-sky-500/20"
+                  >
+                    <DownloadCloud className="h-4 w-4" />
+                    Retrieve
+                  </button>
+                </div>
+                <div className="mt-3 grid gap-3 md:grid-cols-2">
+                  <div>
+                    <label className="text-xs uppercase tracking-[0.3em] text-white/40">Decryption Key</label>
+                    <input
+                      type="password"
+                      value={downloadKeys[file.id] ?? ''}
+                      onChange={(event) =>
+                        setDownloadKeys((previous) => ({
+                          ...previous,
+                          [file.id]: event.target.value,
+                        }))
+                      }
+                      placeholder="Provide key to decrypt"
+                      className="mt-1 w-full rounded-xl border border-white/10 bg-white/5 px-3 py-2 text-sm text-white placeholder:text-white/40 focus:border-white/30 focus:outline-none"
+                    />
+                  </div>
+                  <div>
+                    <p className="text-xs uppercase tracking-[0.3em] text-white/40">Access Vector</p>
+                    <div className="mt-1 flex flex-wrap items-center gap-2 text-xs text-white/60">
+                      {permissions.length > 0 ? (
+                        permissions.map((entry) => (
+                          <span
+                            key={`${file.id}-${entry.userId}`}
+                            className="rounded-full border border-white/10 bg-white/5 px-3 py-1"
+                          >
+                            {entry.userId} · {entry.level}
+                          </span>
+                        ))
+                      ) : (
+                        <span>No permissions recorded.</span>
+                      )}
+                    </div>
+                  </div>
+                </div>
+              </div>
+            );
+          })}
+        </div>
+      </div>
+
+      <footer className="border-t border-white/10 bg-white/5 px-5 py-3 text-xs text-white/50">
+        <div className="flex items-center gap-2">
+          <ShieldCheck className="h-4 w-4 text-emerald-300" />
+          AES-GCM encryption is performed locally in the browser. Keep your passphrases safe—lost keys cannot be recovered.
+        </div>
+      </footer>
+    </div>
+  );
+}

--- a/src/components/interface/workspace/widgets/PrivacyTemplatesWidget.tsx
+++ b/src/components/interface/workspace/widgets/PrivacyTemplatesWidget.tsx
@@ -1,0 +1,120 @@
+import { useEffect, useState } from 'react';
+import { BadgeCheck, Shield, Users } from 'lucide-react';
+import { usePermissionStore } from '../../../../store/permissionStore';
+import { useVaultStore } from '../../../../store/vaultStore';
+import { useAuthStore } from '../../../../store/authStore';
+
+interface WidgetProps {
+  widgetId: string;
+}
+
+export function PrivacyTemplatesWidget({ widgetId }: WidgetProps) {
+  const templates = usePermissionStore((state) => state.templates);
+  const applyTemplate = usePermissionStore((state) => state.applyTemplate);
+  const getPermissionsForResource = usePermissionStore((state) => state.getPermissionsForResource);
+  const ensureResource = usePermissionStore((state) => state.ensureResource);
+  const files = useVaultStore((state) => state.files);
+  const currentUser = useAuthStore((state) => state.user);
+
+  const [selectedResource, setSelectedResource] = useState<string>(files[0]?.id ?? '');
+  const [feedback, setFeedback] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (files.length > 0 && !selectedResource) {
+      setSelectedResource(files[0].id);
+    }
+  }, [files, selectedResource]);
+
+  const handleApply = (templateId: string) => {
+    const resourceId = selectedResource || widgetId;
+    ensureResource(resourceId, resourceId === widgetId ? 'workspace-widget' : 'vault-file', currentUser?.id ?? 'system');
+    const response = applyTemplate(resourceId, templateId, currentUser?.id ?? 'system');
+    setFeedback(response.message);
+  };
+
+  const permissions = getPermissionsForResource(selectedResource || widgetId);
+
+  return (
+    <div className="flex h-full flex-col gap-4 p-5">
+      <div>
+        <p className="text-xs uppercase tracking-[0.3em] text-white/50">Privacy Presets</p>
+        <h4 className="text-lg font-semibold text-white">Deploy Permission Blueprints</h4>
+        <p className="mt-1 text-xs text-white/60">
+          Templates orchestrate who can view or edit vault capsules. Choose a target asset and push a preset to update access instantly.
+        </p>
+      </div>
+
+      <div>
+        <label className="text-xs uppercase tracking-[0.3em] text-white/40">Target Asset</label>
+        <select
+          value={selectedResource}
+          onChange={(event) => setSelectedResource(event.target.value)}
+          className="mt-2 w-full rounded-xl border border-white/10 bg-slate-950/60 px-4 py-3 text-sm text-white focus:border-white/30 focus:outline-none"
+        >
+          <option value="">Workspace Module ({widgetId})</option>
+          {files.map((file) => (
+            <option key={file.id} value={file.id}>
+              {file.name}
+            </option>
+          ))}
+        </select>
+      </div>
+
+      <div className="space-y-3">
+        {templates.map((template) => (
+          <div
+            key={template.id}
+            className="rounded-2xl border border-white/10 bg-white/5 p-4"
+          >
+            <div className="flex items-start justify-between gap-3">
+              <div>
+                <p className="text-sm font-semibold text-white">{template.name}</p>
+                <p className="text-xs text-white/60">{template.description}</p>
+              </div>
+              <button
+                type="button"
+                onClick={() => handleApply(template.id)}
+                className="rounded-lg border border-emerald-400/40 bg-emerald-500/10 px-3 py-2 text-xs uppercase tracking-[0.3em] text-emerald-300 transition hover:bg-emerald-500/20"
+              >
+                Apply
+              </button>
+            </div>
+            <div className="mt-3 flex flex-wrap items-center gap-2 text-xs text-white/50">
+              <BadgeCheck className="h-4 w-4 text-emerald-300" />
+              {template.grants.map((rule) => (
+                <span key={`${template.id}-${rule.target}-${rule.level}`} className="rounded-full border border-white/10 bg-white/5 px-3 py-1">
+                  {rule.target} · {rule.level}
+                </span>
+              ))}
+            </div>
+          </div>
+        ))}
+      </div>
+
+      {feedback && <p className="text-xs text-white/50">{feedback}</p>}
+
+      <div className="rounded-2xl border border-white/10 bg-white/5 p-4">
+        <div className="flex items-center gap-2 text-xs uppercase tracking-[0.3em] text-white/50">
+          <Shield className="h-4 w-4 text-emerald-300" /> Current Access Graph
+        </div>
+        <div className="mt-3 space-y-2">
+          {permissions.length > 0 ? (
+            permissions.map((entry) => (
+              <div
+                key={`${entry.userId}-${entry.level}`}
+                className="flex items-center justify-between rounded-xl border border-white/10 bg-slate-950/60 px-3 py-2 text-xs text-white/60"
+              >
+                <span className="flex items-center gap-2">
+                  <Users className="h-4 w-4 text-white/40" /> {entry.userId}
+                </span>
+                <span className="rounded-full border border-white/10 bg-white/5 px-3 py-1 text-white/60">{entry.level}</span>
+              </div>
+            ))
+          ) : (
+            <p className="text-xs text-white/40">No permissions have been recorded for the selected asset.</p>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/interface/workspace/widgets/WidgetManagementWidget.tsx
+++ b/src/components/interface/workspace/widgets/WidgetManagementWidget.tsx
@@ -1,0 +1,193 @@
+import { useState } from 'react';
+import { LayoutGrid, RefreshCcw, Rows3 } from 'lucide-react';
+import {
+  useWorkspaceStore,
+  WorkspaceWidgetKey,
+  WorkspaceDensity,
+  WorkspaceArrangement,
+} from '../../../../store/workspaceStore';
+
+interface WidgetProps {
+  widgetId: WorkspaceWidgetKey;
+}
+
+const sizeOptions: Array<{ label: string; value: 'full' | 'half' }> = [
+  { label: 'Expanded (2 columns)', value: 'full' },
+  { label: 'Compact (1 column)', value: 'half' },
+];
+
+export function WidgetManagementWidget({ widgetId: _widgetId }: WidgetProps) {
+  const registry = useWorkspaceStore((state) => state.registry);
+  const layout = useWorkspaceStore((state) => state.layout);
+  const toggleWidget = useWorkspaceStore((state) => state.toggleWidget);
+  const isWidgetActive = useWorkspaceStore((state) => state.isWidgetActive);
+  const setWidgetSize = useWorkspaceStore((state) => state.setWidgetSize);
+  const preferences = useWorkspaceStore((state) => state.preferences);
+  const resetLayout = useWorkspaceStore((state) => state.resetLayout);
+  const focusWidget = useWorkspaceStore((state) => state.focusWidget);
+  const layoutDensity = useWorkspaceStore((state) => state.layoutDensity);
+  const setLayoutDensity = useWorkspaceStore((state) => state.setLayoutDensity);
+  const arrangement = useWorkspaceStore((state) => state.arrangement);
+  const setArrangement = useWorkspaceStore((state) => state.setArrangement);
+  const [expandedWidget, setExpandedWidget] = useState<WorkspaceWidgetKey | null>(null);
+
+  const densityOptionsToolbar: Array<{ value: WorkspaceDensity; label: string }> = [
+    { value: 'compact', label: 'Compact grid' },
+    { value: 'balanced', label: 'Balanced grid' },
+    { value: 'spacious', label: 'Spacious grid' },
+  ];
+
+  const arrangementOptionsToolbar: Array<{ value: WorkspaceArrangement; label: string }> = [
+    { value: 'manual', label: 'Manual order' },
+    { value: 'alphabetical', label: 'Alphabetical order' },
+    { value: 'category', label: 'Category clusters' },
+  ];
+
+  const categoryLabels = {
+    security: 'Security',
+    governance: 'Governance',
+    operations: 'Operations',
+  } as const;
+
+  return (
+    <div className="flex h-full flex-col gap-4 p-5">
+      <div className="flex items-center justify-between">
+        <div>
+          <p className="text-xs uppercase tracking-[0.3em] text-white/50">Widget Library</p>
+          <h4 className="text-lg font-semibold text-white">Configure Workspace Blocks</h4>
+        </div>
+        <button
+          type="button"
+          onClick={resetLayout}
+          className="flex items-center gap-2 rounded-xl border border-white/10 bg-white/10 px-3 py-2 text-xs uppercase tracking-[0.3em] text-white/60 transition hover:bg-white/20"
+        >
+          <RefreshCcw className="h-4 w-4" /> Reset Layout
+        </button>
+      </div>
+
+      <div className="grid gap-2 rounded-2xl border border-white/10 bg-white/5 p-4 text-[11px] uppercase tracking-[0.3em] text-white/50">
+        <p className="text-white/60">Global layout presets</p>
+        <div className="flex flex-col gap-2">
+          <label className="flex items-center justify-between gap-2 rounded-xl border border-white/10 bg-white/5 px-3 py-2 text-white/60">
+            <span>Density</span>
+            <select
+              value={layoutDensity}
+              onChange={(event) => setLayoutDensity(event.target.value as WorkspaceDensity)}
+              className="bg-transparent text-[11px] uppercase tracking-[0.3em] text-white/70 focus:outline-none"
+            >
+              {densityOptionsToolbar.map((option) => (
+                <option key={option.value} value={option.value} className="bg-slate-900 text-white">
+                  {option.label}
+                </option>
+              ))}
+            </select>
+          </label>
+          <label className="flex items-center justify-between gap-2 rounded-xl border border-white/10 bg-white/5 px-3 py-2 text-white/60">
+            <span>Arrangement</span>
+            <select
+              value={arrangement}
+              onChange={(event) => setArrangement(event.target.value as WorkspaceArrangement)}
+              className="bg-transparent text-[11px] uppercase tracking-[0.3em] text-white/70 focus:outline-none"
+            >
+              {arrangementOptionsToolbar.map((option) => (
+                <option key={option.value} value={option.value} className="bg-slate-900 text-white">
+                  {option.label}
+                </option>
+              ))}
+            </select>
+          </label>
+        </div>
+      </div>
+
+      <div className="space-y-3">
+        {Object.values(registry).map((widget) => {
+          const active = isWidgetActive(widget.id);
+          const preference = preferences[widget.id];
+          const isExpanded = expandedWidget === widget.id;
+          return (
+            <div
+              key={widget.id}
+              className={`rounded-2xl border px-4 py-4 transition ${
+                active ? 'border-emerald-400/40 bg-emerald-500/10' : 'border-white/10 bg-white/5'
+              }`}
+            >
+              <div className="flex flex-wrap items-start justify-between gap-3">
+                <div className="space-y-1">
+                  <span className="inline-flex items-center gap-2 rounded-full border border-white/10 bg-white/5 px-3 py-1 text-[10px] uppercase tracking-[0.3em] text-white/50">
+                    {categoryLabels[widget.category]}
+                  </span>
+                  <p className="text-sm font-semibold text-white">{widget.title}</p>
+                  <p className="text-xs text-white/60">{widget.description}</p>
+                </div>
+                <div className="flex items-center gap-2">
+                  <button
+                    type="button"
+                    onClick={() => focusWidget(widget.id)}
+                    className="rounded-lg border border-sky-400/40 bg-sky-500/10 px-3 py-2 text-xs uppercase tracking-[0.3em] text-sky-200 transition hover:bg-sky-500/20"
+                  >
+                    Focus
+                  </button>
+                  <button
+                    type="button"
+                    onClick={() => toggleWidget(widget.id)}
+                    className={`rounded-lg border px-3 py-2 text-xs uppercase tracking-[0.3em] transition ${
+                      active
+                        ? 'border-rose-400/40 bg-rose-500/10 text-rose-200 hover:bg-rose-500/20'
+                        : 'border-emerald-400/40 bg-emerald-500/10 text-emerald-300 hover:bg-emerald-500/20'
+                    }`}
+                  >
+                    {active ? 'Remove' : 'Activate'}
+                  </button>
+                </div>
+              </div>
+
+              <button
+                type="button"
+                onClick={() => setExpandedWidget((current) => (current === widget.id ? null : widget.id))}
+                className="mt-3 flex w-full items-center gap-2 text-xs uppercase tracking-[0.3em] text-white/60"
+              >
+                <Rows3 className="h-4 w-4 text-white/40" />
+                Layout Options
+              </button>
+
+              {isExpanded && (
+                <div className="mt-3 space-y-3 rounded-xl border border-white/10 bg-white/5 p-3 text-sm text-white/70">
+                  <div className="flex flex-col gap-2">
+                    <label className="text-xs uppercase tracking-[0.3em] text-white/40">Width Preference</label>
+                    <div className="grid gap-2">
+                      {sizeOptions.map((option) => (
+                        <label
+                          key={option.value}
+                          className={`flex cursor-pointer items-center justify-between rounded-lg border px-3 py-2 text-xs uppercase tracking-[0.3em] transition ${
+                            (preference?.size ?? widget.defaultSize) === option.value
+                              ? 'border-emerald-400/40 bg-emerald-500/10 text-emerald-200'
+                              : 'border-white/10 bg-white/5 text-white/60 hover:bg-white/10'
+                          }`}
+                        >
+                          <span className="flex items-center gap-2">
+                            <LayoutGrid className="h-4 w-4" /> {option.label}
+                          </span>
+                          <input
+                            type="radio"
+                            name={`${widget.id}-size`}
+                            value={option.value}
+                            checked={(preference?.size ?? widget.defaultSize) === option.value}
+                            onChange={() => setWidgetSize(widget.id, option.value)}
+                            className="hidden"
+                          />
+                        </label>
+                      ))}
+                    </div>
+                  </div>
+                  <p className="text-xs text-white/40">
+                    Active widgets: {layout.length}. Drag-order adjustments are available directly from each widget header.
+                  </p>
+                </div>
+              )}
+            </div>
+          );
+        })}
+      </div>
+    </div>
+  );
+}

--- a/src/services/encryptionService.ts
+++ b/src/services/encryptionService.ts
@@ -1,0 +1,64 @@
+const textEncoder = new TextEncoder();
+
+function arrayBufferToBase64(buffer: ArrayBuffer): string {
+  const bytes = new Uint8Array(buffer);
+  let binary = '';
+  bytes.forEach((byte) => {
+    binary += String.fromCharCode(byte);
+  });
+  return btoa(binary);
+}
+
+function base64ToArrayBuffer(base64: string): ArrayBuffer {
+  const binary = atob(base64);
+  const bytes = new Uint8Array(binary.length);
+  for (let i = 0; i < binary.length; i += 1) {
+    bytes[i] = binary.charCodeAt(i);
+  }
+  return bytes.buffer;
+}
+
+async function deriveKey(passphrase: string): Promise<CryptoKey> {
+  if (!passphrase) {
+    throw new Error('An encryption key is required.');
+  }
+  const passphraseData = textEncoder.encode(passphrase);
+  const hashBuffer = await crypto.subtle.digest('SHA-256', passphraseData);
+  return crypto.subtle.importKey('raw', hashBuffer, { name: 'AES-GCM' }, false, [
+    'encrypt',
+    'decrypt',
+  ]);
+}
+
+export interface EncryptedPayload {
+  data: string;
+  iv: string;
+  mimeType: string;
+  size: number;
+}
+
+export async function encryptFile(file: File, passphrase: string): Promise<EncryptedPayload> {
+  const key = await deriveKey(passphrase);
+  const iv = crypto.getRandomValues(new Uint8Array(12));
+  const fileBuffer = await file.arrayBuffer();
+  const encrypted = await crypto.subtle.encrypt({ name: 'AES-GCM', iv }, key, fileBuffer);
+
+  return {
+    data: arrayBufferToBase64(encrypted),
+    iv: arrayBufferToBase64(iv.buffer),
+    mimeType: file.type || 'application/octet-stream',
+    size: file.size,
+  };
+}
+
+export async function decryptPayload(payload: EncryptedPayload, passphrase: string): Promise<ArrayBuffer> {
+  const key = await deriveKey(passphrase);
+  const ivBuffer = base64ToArrayBuffer(payload.iv);
+  const encryptedBuffer = base64ToArrayBuffer(payload.data);
+  return crypto.subtle.decrypt({ name: 'AES-GCM', iv: new Uint8Array(ivBuffer) }, key, encryptedBuffer);
+}
+
+export function payloadToObjectUrl(payload: ArrayBuffer, mimeType: string): string {
+  const blob = new Blob([payload], { type: mimeType });
+  return URL.createObjectURL(blob);
+}

--- a/src/services/permissionService.ts
+++ b/src/services/permissionService.ts
@@ -1,0 +1,63 @@
+export type PermissionLevel = 'owner' | 'editor' | 'viewer';
+
+type TemplateTarget = 'self' | 'all' | 'others' | 'online';
+
+export interface PermissionTemplate {
+  id: string;
+  name: string;
+  description: string;
+  tag: 'Private' | 'Team' | 'Broadcast';
+  grants: Array<{ target: TemplateTarget; level: PermissionLevel }>;
+}
+
+export const permissionRank: Record<PermissionLevel, number> = {
+  owner: 3,
+  editor: 2,
+  viewer: 1,
+};
+
+export function canAccess(current: PermissionLevel, required: PermissionLevel): boolean {
+  return permissionRank[current] >= permissionRank[required];
+}
+
+export const permissionTemplates: PermissionTemplate[] = [
+  {
+    id: 'solo-lockdown',
+    name: 'Solo Lockdown',
+    description: 'Restrict access to the linked operator only. Ideal for personal drafts or red team drops.',
+    tag: 'Private',
+    grants: [
+      { target: 'self', level: 'owner' },
+    ],
+  },
+  {
+    id: 'ops-squad',
+    name: 'Ops Squad Sync',
+    description: 'Grant edit capabilities to the broader ops team while keeping ownership rights.',
+    tag: 'Team',
+    grants: [
+      { target: 'self', level: 'owner' },
+      { target: 'others', level: 'editor' },
+    ],
+  },
+  {
+    id: 'broadcast-audit',
+    name: 'Broadcast Audit',
+    description: 'Allow every registered operator to view the asset for limited-time audit scenarios.',
+    tag: 'Broadcast',
+    grants: [
+      { target: 'self', level: 'owner' },
+      { target: 'all', level: 'viewer' },
+    ],
+  },
+  {
+    id: 'live-online',
+    name: 'Live Online Cohort',
+    description: 'Share with operators currently online while maintaining editing authority yourself.',
+    tag: 'Team',
+    grants: [
+      { target: 'self', level: 'owner' },
+      { target: 'online', level: 'editor' },
+    ],
+  },
+];

--- a/src/store/activityLogStore.ts
+++ b/src/store/activityLogStore.ts
@@ -1,0 +1,58 @@
+import { create } from 'zustand';
+import { persist } from 'zustand/middleware';
+import { useUserStore } from './userStore';
+
+export type ActivityStatus = 'success' | 'warning' | 'error';
+
+export interface ActivityLogEntry {
+  id: string;
+  timestamp: number;
+  actorId: string;
+  actorName: string;
+  action:
+    | 'FILE_UPLOADED'
+    | 'FILE_DOWNLOAD_ATTEMPT'
+    | 'FILE_DOWNLOAD_SUCCESS'
+    | 'PERMISSION_TEMPLATE_APPLIED'
+    | 'PERMISSION_GRANTED'
+    | 'PERMISSION_REVOKED';
+  message: string;
+  resourceId?: string;
+  status: ActivityStatus;
+}
+
+interface ActivityLogState {
+  entries: ActivityLogEntry[];
+  addLog: (entry: Omit<ActivityLogEntry, 'id' | 'timestamp' | 'actorName'> & { actorName?: string }) => void;
+  clearLog: () => void;
+}
+
+export const useActivityLogStore = create<ActivityLogState>()(
+  persist(
+    (set, _get) => ({
+      entries: [],
+      addLog: (entry) => {
+        const users = useUserStore.getState().users;
+        const actor = users.find((user) => user.id === entry.actorId);
+        const logEntry: ActivityLogEntry = {
+          id: `log_${Date.now()}_${Math.random().toString(36).slice(2, 8)}`,
+          timestamp: Date.now(),
+          actorId: entry.actorId,
+          actorName: entry.actorName ?? actor?.name ?? 'System',
+          action: entry.action,
+          message: entry.message,
+          resourceId: entry.resourceId,
+          status: entry.status,
+        };
+
+        set((state) => ({
+          entries: [logEntry, ...state.entries].slice(0, 100),
+        }));
+      },
+      clearLog: () => set({ entries: [] }),
+    }),
+    {
+      name: 'workspace-activity-log',
+    }
+  )
+);

--- a/src/store/permissionStore.ts
+++ b/src/store/permissionStore.ts
@@ -1,0 +1,209 @@
+import { create } from 'zustand';
+import { persist } from 'zustand/middleware';
+import { permissionTemplates, PermissionTemplate, PermissionLevel, canAccess, permissionRank } from '../services/permissionService';
+import { useUserStore } from './userStore';
+import { useActivityLogStore } from './activityLogStore';
+
+export interface ResourcePermissionEntry {
+  userId: string;
+  level: PermissionLevel;
+}
+
+export interface ResourcePermission {
+  resourceId: string;
+  resourceType: 'vault-file' | 'workspace-widget';
+  entries: ResourcePermissionEntry[];
+  templateId?: string;
+  updatedAt: number;
+}
+
+interface PermissionState {
+  resources: Record<string, ResourcePermission>;
+  templates: PermissionTemplate[];
+  ensureResource: (resourceId: string, resourceType: ResourcePermission['resourceType'], ownerId: string) => void;
+  applyTemplate: (resourceId: string, templateId: string, actorId: string) => { success: boolean; message: string };
+  grantPermission: (
+    resourceId: string,
+    userId: string,
+    level: PermissionLevel,
+    actorId: string,
+    options?: { silent?: boolean }
+  ) => void;
+  revokePermission: (resourceId: string, userId: string, actorId: string) => void;
+  hasAccess: (resourceId: string, userId: string | null | undefined, requiredLevel?: PermissionLevel) => boolean;
+  getPermissionsForResource: (resourceId: string) => ResourcePermissionEntry[];
+}
+
+export const usePermissionStore = create<PermissionState>()(
+  persist(
+    (set, get) => ({
+      resources: {},
+      templates: permissionTemplates,
+      ensureResource: (resourceId, resourceType, ownerId) => {
+        const { resources } = get();
+        if (resources[resourceId]) return;
+        const baseline: ResourcePermission = {
+          resourceId,
+          resourceType,
+          entries: [{ userId: ownerId, level: 'owner' }],
+          updatedAt: Date.now(),
+        };
+        set({ resources: { ...resources, [resourceId]: baseline } });
+      },
+      applyTemplate: (resourceId, templateId, actorId) => {
+        const template = permissionTemplates.find((preset) => preset.id === templateId);
+        if (!template) {
+          return { success: false, message: 'Template not found.' };
+        }
+        const users = useUserStore.getState().users;
+        const actor = users.find((user) => user.id === actorId);
+        const allUserIds = users.map((user) => user.id);
+        const onlineUserIds = users.filter((user) => user.online).map((user) => user.id);
+        const otherUserIds = users.filter((user) => user.id !== actorId).map((user) => user.id);
+
+        const grants = template.grants.reduce<Record<string, PermissionLevel>>((accumulator, rule) => {
+          let targets: string[] = [];
+          switch (rule.target) {
+            case 'self':
+              targets = actorId ? [actorId] : [];
+              break;
+            case 'all':
+              targets = allUserIds;
+              break;
+            case 'others':
+              targets = otherUserIds;
+              break;
+            case 'online':
+              targets = onlineUserIds;
+              break;
+            default:
+              targets = [];
+          }
+          targets.forEach((userId) => {
+            const currentLevel = accumulator[userId];
+            if (!currentLevel || permissionRank[rule.level] > permissionRank[currentLevel]) {
+              accumulator[userId] = rule.level;
+            }
+          });
+          return accumulator;
+        }, {});
+
+        if (actorId && !grants[actorId]) {
+          grants[actorId] = 'owner';
+        }
+
+        const entries: ResourcePermissionEntry[] = Object.entries(grants).map(([userId, level]) => ({
+          userId,
+          level,
+        }));
+
+        set((state) => ({
+          resources: {
+            ...state.resources,
+            [resourceId]: {
+              resourceId,
+              resourceType: state.resources[resourceId]?.resourceType ?? 'vault-file',
+              entries,
+              templateId,
+              updatedAt: Date.now(),
+            },
+          },
+        }));
+
+        const actorName = actor?.name ?? 'System';
+        useActivityLogStore.getState().addLog({
+          actorId,
+          actorName,
+          action: 'PERMISSION_TEMPLATE_APPLIED',
+          message: `${actorName} applied the ${template.name} template to ${resourceId}.`,
+          resourceId,
+          status: 'success',
+        });
+
+        return { success: true, message: `${template.name} applied.` };
+      },
+      grantPermission: (resourceId, userId, level, actorId, options) => {
+        set((state) => {
+          const resource = state.resources[resourceId];
+          if (!resource) return state;
+          const nextEntries = resource.entries.filter((entry) => entry.userId !== userId);
+          nextEntries.push({ userId, level });
+          const updated: ResourcePermission = {
+            ...resource,
+            entries: nextEntries,
+            updatedAt: Date.now(),
+          };
+
+          if (!options?.silent) {
+            const actor = useUserStore.getState().users.find((user) => user.id === actorId);
+            const subject = useUserStore.getState().users.find((user) => user.id === userId);
+            useActivityLogStore.getState().addLog({
+              actorId,
+              actorName: actor?.name ?? 'System',
+              action: 'PERMISSION_GRANTED',
+              message: `${actor?.name ?? 'System'} granted ${level} access to ${subject?.name ?? userId} on ${resourceId}.`,
+              resourceId,
+              status: 'success',
+            });
+          }
+
+          return {
+            resources: {
+              ...state.resources,
+              [resourceId]: updated,
+            },
+          };
+        });
+      },
+      revokePermission: (resourceId, userId, actorId) => {
+        set((state) => {
+          const resource = state.resources[resourceId];
+          if (!resource) return state;
+          const filteredEntries = resource.entries.filter((entry) => entry.userId !== userId);
+          const updated: ResourcePermission = {
+            ...resource,
+            entries: filteredEntries,
+            updatedAt: Date.now(),
+          };
+
+          const actor = useUserStore.getState().users.find((user) => user.id === actorId);
+          const subject = useUserStore.getState().users.find((user) => user.id === userId);
+          useActivityLogStore.getState().addLog({
+            actorId,
+            actorName: actor?.name ?? 'System',
+            action: 'PERMISSION_REVOKED',
+            message: `${actor?.name ?? 'System'} revoked access for ${subject?.name ?? userId} on ${resourceId}.`,
+            resourceId,
+            status: 'warning',
+          });
+
+          return {
+            resources: {
+              ...state.resources,
+              [resourceId]: updated,
+            },
+          };
+        });
+      },
+      hasAccess: (resourceId, userId, requiredLevel = 'viewer') => {
+        if (!userId) return false;
+        const { resources } = get();
+        const resource = resources[resourceId];
+        if (!resource) return false;
+        const entry = resource.entries.find((item) => item.userId === userId);
+        if (!entry) return false;
+        return canAccess(entry.level, requiredLevel);
+      },
+      getPermissionsForResource: (resourceId) => {
+        const resource = get().resources[resourceId];
+        return resource ? [...resource.entries].sort((a, b) => permissionRank[b.level] - permissionRank[a.level]) : [];
+      },
+    }),
+    {
+      name: 'workspace-permissions',
+      partialize: (state) => ({
+        resources: state.resources,
+      }),
+    }
+  )
+);

--- a/src/store/vaultStore.ts
+++ b/src/store/vaultStore.ts
@@ -1,0 +1,133 @@
+import { create } from 'zustand';
+import { persist } from 'zustand/middleware';
+import { encryptFile, decryptPayload, payloadToObjectUrl, EncryptedPayload } from '../services/encryptionService';
+import { useAuthStore } from './authStore';
+import { usePermissionStore } from './permissionStore';
+import { useActivityLogStore } from './activityLogStore';
+
+export interface VaultFile {
+  id: string;
+  name: string;
+  size: number;
+  mimeType: string;
+  ownerId: string;
+  encryptedPayload: EncryptedPayload;
+  uploadedAt: number;
+}
+
+interface VaultState {
+  files: VaultFile[];
+  uploadFile: (file: File, encryptionKey: string) => Promise<{ success: boolean; message: string }>;
+  requestDownload: (
+    fileId: string,
+    encryptionKey: string
+  ) => Promise<{ success: true; objectUrl: string; fileName: string } | { success: false; message: string }>;
+}
+
+export const useVaultStore = create<VaultState>()(
+  persist(
+    (set, get) => ({
+      files: [],
+      uploadFile: async (file, encryptionKey) => {
+        const currentUser = useAuthStore.getState().user;
+        if (!currentUser) {
+          return { success: false, message: 'Authentication required before uploading.' };
+        }
+        if (!file) {
+          return { success: false, message: 'A file must be selected.' };
+        }
+        if (!encryptionKey) {
+          return { success: false, message: 'Provide an encryption key to secure the upload.' };
+        }
+
+        try {
+          const encryptedPayload = await encryptFile(file, encryptionKey);
+          const vaultEntry: VaultFile = {
+            id: `vault_${Date.now()}_${Math.random().toString(36).slice(2, 8)}`,
+            name: file.name,
+            size: file.size,
+            mimeType: encryptedPayload.mimeType,
+            ownerId: currentUser.id,
+            encryptedPayload,
+            uploadedAt: Date.now(),
+          };
+
+          set((state) => ({ files: [vaultEntry, ...state.files] }));
+
+          usePermissionStore
+            .getState()
+            .ensureResource(vaultEntry.id, 'vault-file', currentUser.id);
+
+          useActivityLogStore.getState().addLog({
+            actorId: currentUser.id,
+            action: 'FILE_UPLOADED',
+            message: `${currentUser.name} secured ${file.name} in the encrypted vault.`,
+            resourceId: vaultEntry.id,
+            status: 'success',
+          });
+
+          return { success: true, message: `${file.name} encrypted and stored.` };
+        } catch (error) {
+          console.error(error);
+          return { success: false, message: 'Failed to encrypt file. Verify the encryption key.' };
+        }
+      },
+      requestDownload: async (fileId, encryptionKey) => {
+        const currentUser = useAuthStore.getState().user;
+        if (!currentUser) {
+          return { success: false, message: 'Authentication required before download.' };
+        }
+
+        const file = get().files.find((item) => item.id === fileId);
+        if (!file) {
+          return { success: false, message: 'File not found in vault.' };
+        }
+
+        useActivityLogStore.getState().addLog({
+          actorId: currentUser.id,
+          action: 'FILE_DOWNLOAD_ATTEMPT',
+          message: `${currentUser.name} initiated a download attempt for ${file.name}.`,
+          resourceId: file.id,
+          status: 'warning',
+        });
+
+        const hasAccess = usePermissionStore
+          .getState()
+          .hasAccess(file.id, currentUser.id, 'viewer');
+
+        if (!hasAccess) {
+          useActivityLogStore.getState().addLog({
+            actorId: currentUser.id,
+            action: 'FILE_DOWNLOAD_ATTEMPT',
+            message: `${currentUser.name} was blocked from accessing ${file.name} due to insufficient permissions.`,
+            resourceId: file.id,
+            status: 'error',
+          });
+          return { success: false, message: 'Permission denied for this file.' };
+        }
+
+        try {
+          const decrypted = await decryptPayload(file.encryptedPayload, encryptionKey);
+          const objectUrl = payloadToObjectUrl(decrypted, file.mimeType);
+
+          useActivityLogStore.getState().addLog({
+            actorId: currentUser.id,
+            action: 'FILE_DOWNLOAD_SUCCESS',
+            message: `${currentUser.name} successfully retrieved ${file.name} from the vault.`,
+            resourceId: file.id,
+            status: 'success',
+          });
+
+          return { success: true, objectUrl, fileName: file.name };
+        } catch (error) {
+          console.error(error);
+          return { success: false, message: 'Unable to decrypt file with provided key.' };
+        }
+      },
+    }),
+    {
+      name: 'workspace-vault',
+      partialize: (state) => ({ files: state.files }),
+    }
+  )
+);

--- a/src/store/workspaceStore.ts
+++ b/src/store/workspaceStore.ts
@@ -1,0 +1,185 @@
+import { create } from 'zustand';
+import { persist } from 'zustand/middleware';
+
+export type WorkspaceWidgetKey =
+  | 'encryptedVault'
+  | 'privacyTemplates'
+  | 'activityLog'
+  | 'widgetManager';
+
+export type WorkspaceWidgetCategory = 'security' | 'governance' | 'operations';
+
+export type WorkspaceDensity = 'balanced' | 'compact' | 'spacious';
+
+export type WorkspaceArrangement = 'manual' | 'alphabetical' | 'category';
+
+export interface WorkspaceWidget {
+  id: WorkspaceWidgetKey;
+  title: string;
+  description: string;
+  defaultSize: 'full' | 'half';
+  category: WorkspaceWidgetCategory;
+}
+
+interface WidgetPreferences {
+  size: 'full' | 'half';
+}
+
+interface WorkspaceState {
+  registry: Record<WorkspaceWidgetKey, WorkspaceWidget>;
+  layout: WorkspaceWidgetKey[];
+  minimized: Record<WorkspaceWidgetKey, boolean>;
+  preferences: Partial<Record<WorkspaceWidgetKey, WidgetPreferences>>;
+  focusedWidget: WorkspaceWidgetKey | null;
+  layoutDensity: WorkspaceDensity;
+  arrangement: WorkspaceArrangement;
+  activeCategory: 'all' | WorkspaceWidgetCategory;
+  addWidget: (widgetId: WorkspaceWidgetKey) => void;
+  removeWidget: (widgetId: WorkspaceWidgetKey) => void;
+  toggleWidget: (widgetId: WorkspaceWidgetKey) => void;
+  moveWidget: (widgetId: WorkspaceWidgetKey, direction: 'up' | 'down') => void;
+  toggleCollapse: (widgetId: WorkspaceWidgetKey) => void;
+  setWidgetSize: (widgetId: WorkspaceWidgetKey, size: 'full' | 'half') => void;
+  isWidgetActive: (widgetId: WorkspaceWidgetKey) => boolean;
+  resetLayout: () => void;
+  focusWidget: (widgetId: WorkspaceWidgetKey) => void;
+  clearFocus: () => void;
+  setLayoutDensity: (density: WorkspaceDensity) => void;
+  setArrangement: (arrangement: WorkspaceArrangement) => void;
+  setActiveCategory: (category: 'all' | WorkspaceWidgetCategory) => void;
+}
+
+const defaultRegistry: Record<WorkspaceWidgetKey, WorkspaceWidget> = {
+  encryptedVault: {
+    id: 'encryptedVault',
+    title: 'Encrypted File Vault',
+    description: 'Manage zero-trust file capsules with AES-GCM encryption and permission-aware sharing.',
+    defaultSize: 'full',
+    category: 'security',
+  },
+  privacyTemplates: {
+    id: 'privacyTemplates',
+    title: 'Privacy Template Presets',
+    description: 'Apply curated permission blueprints to vault assets and workspace modules.',
+    defaultSize: 'half',
+    category: 'governance',
+  },
+  activityLog: {
+    id: 'activityLog',
+    title: 'Activity & Permission Log',
+    description: 'Review an immutable feed of access requests, grants, and storage events.',
+    defaultSize: 'half',
+    category: 'governance',
+  },
+  widgetManager: {
+    id: 'widgetManager',
+    title: 'Widget Management',
+    description: 'Curate workspace widgets, layout density, and visibility controls for operators.',
+    defaultSize: 'half',
+    category: 'operations',
+  },
+};
+
+const defaultLayout: WorkspaceWidgetKey[] = [
+  'encryptedVault',
+  'privacyTemplates',
+  'activityLog',
+];
+
+export const useWorkspaceStore = create<WorkspaceState>()(
+  persist(
+    (set, get) => ({
+      registry: defaultRegistry,
+      layout: defaultLayout,
+      minimized: {},
+      preferences: {},
+      focusedWidget: null,
+      layoutDensity: 'balanced',
+      arrangement: 'manual',
+      activeCategory: 'all',
+      addWidget: (widgetId) => {
+        const { layout } = get();
+        if (layout.includes(widgetId)) return;
+        set({ layout: [...layout, widgetId] });
+      },
+      removeWidget: (widgetId) => {
+        const { layout } = get();
+        set({ layout: layout.filter((item) => item !== widgetId) });
+      },
+      toggleWidget: (widgetId) => {
+        const { layout } = get();
+        if (layout.includes(widgetId)) {
+          set({ layout: layout.filter((item) => item !== widgetId) });
+        } else {
+          set({ layout: [...layout, widgetId] });
+        }
+      },
+      moveWidget: (widgetId, direction) => {
+        const { layout } = get();
+        const index = layout.indexOf(widgetId);
+        if (index === -1) return;
+        const targetIndex = direction === 'up' ? index - 1 : index + 1;
+        if (targetIndex < 0 || targetIndex >= layout.length) return;
+        const newLayout = [...layout];
+        const [removed] = newLayout.splice(index, 1);
+        newLayout.splice(targetIndex, 0, removed);
+        set({ layout: newLayout });
+      },
+      toggleCollapse: (widgetId) => {
+        set((state) => ({
+          minimized: {
+            ...state.minimized,
+            [widgetId]: !state.minimized[widgetId],
+          },
+        }));
+      },
+      setWidgetSize: (widgetId, size) => {
+        set((state) => ({
+          preferences: {
+            ...state.preferences,
+            [widgetId]: {
+              ...(state.preferences[widgetId] ?? { size: state.registry[widgetId]?.defaultSize ?? 'full' }),
+              size,
+            },
+          },
+        }));
+      },
+      isWidgetActive: (widgetId) => get().layout.includes(widgetId),
+      resetLayout: () =>
+        set({
+          layout: defaultLayout,
+          minimized: {},
+          preferences: {},
+          layoutDensity: 'balanced',
+          arrangement: 'manual',
+          activeCategory: 'all',
+        }),
+      focusWidget: (widgetId) => {
+        const { layout } = get();
+        if (!layout.includes(widgetId)) {
+          set({ layout: [widgetId, ...layout] });
+        } else {
+          set({
+            layout: [widgetId, ...layout.filter((item) => item !== widgetId)],
+          });
+        }
+        set({ focusedWidget: widgetId });
+      },
+      clearFocus: () => set({ focusedWidget: null }),
+      setLayoutDensity: (density) => set({ layoutDensity: density }),
+      setArrangement: (arrangement) => set({ arrangement }),
+      setActiveCategory: (category) => set({ activeCategory: category }),
+    }),
+    {
+      name: 'workspace-layout',
+      partialize: (state) => ({
+        layout: state.layout,
+        minimized: state.minimized,
+        preferences: state.preferences,
+        layoutDensity: state.layoutDensity,
+        arrangement: state.arrangement,
+        activeCategory: state.activeCategory,
+      }),
+    }
+  )
+);


### PR DESCRIPTION
## Summary
- add persistent layout density, arrangement, and category filters for the workspace deck
- reorganize the workspace grid with balanced spans and category badges for each widget
- group quick actions into a dropdown and expose global layout controls in the widget manager documentation

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e2b6d8a7e48323870a047c00a2b36a