### PR TITLE
Add operations board for mission control and alert workflow

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -11,6 +11,7 @@ import { HeaderBar } from './components/interface/HeaderBar';
 import { ControlPanel } from './components/interface/ControlPanel';
 import { BroadcastPanel } from './components/interface/BroadcastPanel';
 import { FieldNotesPanel } from './components/interface/FieldNotesPanel';
+import { OperationsBoard } from './components/interface/OperationsBoard';
 
 export function App() {
   const isAuthenticated = useAuthStore((state) => state.isAuthenticated);
@@ -53,7 +54,10 @@ export function App() {
 
           <main className="grid flex-1 gap-6 lg:grid-cols-[320px_minmax(0,1fr)_320px] xl:grid-cols-[340px_minmax(0,1fr)_340px]">
             <ControlPanel />
-            <BroadcastPanel />
+            <div className="flex flex-col gap-6">
+              <BroadcastPanel />
+              <OperationsBoard />
+            </div>
             <FieldNotesPanel />
           </main>
 

--- a/src/components/interface/ControlPanel.tsx
+++ b/src/components/interface/ControlPanel.tsx
@@ -3,7 +3,9 @@ import { useAuthStore } from '../../store/authStore';
 import { useUserStore } from '../../store/userStore';
 import { useChatStore } from '../../store/chatStore';
 import { useModalStore } from '../../store/modalStore';
-import { Activity, ShieldCheck, SignalHigh, Waves } from 'lucide-react';
+import { Activity, ShieldCheck, SignalHigh, Waves, BellRing, Rocket } from 'lucide-react';
+import { useNotificationStore } from '../../store/notificationStore';
+import { useMissionStore } from '../../store/missionStore';
 
 export function ControlPanel() {
   const currentUser = useAuthStore((state) => state.user);
@@ -12,6 +14,10 @@ export function ControlPanel() {
   const offlineUsers = users.filter((user) => !user.online);
   const setActiveChat = useChatStore((state) => state.setActiveChat);
   const setProfileUserId = useModalStore((state) => state.setProfileUserId);
+  const activeAlerts = useNotificationStore((state) => state.getActiveNotifications());
+  const liveMissions = useMissionStore((state) =>
+    state.missions.filter((mission) => mission.status !== 'completed')
+  );
 
   const otherUsers = users.filter((user) => user.id !== currentUser?.id);
 
@@ -42,7 +48,7 @@ export function ControlPanel() {
             <div className="pointer-events-none absolute inset-0 rounded-2xl border border-white/5" />
           </div>
 
-          <div className="grid grid-cols-3 gap-4 text-sm">
+          <div className="grid grid-cols-2 gap-4 text-sm md:grid-cols-4">
             <div className="rounded-2xl border border-white/10 bg-white/5 p-3">
               <div className="flex items-center justify-between text-white/60">
                 <span>Active Nodes</span>
@@ -63,6 +69,13 @@ export function ControlPanel() {
                 <SignalHigh className="h-4 w-4 text-fuchsia-300" />
               </div>
               <p className="mt-2 text-2xl font-semibold text-emerald-300">99.2%</p>
+            </div>
+            <div className="rounded-2xl border border-white/10 bg-white/5 p-3">
+              <div className="flex items-center justify-between text-white/60">
+                <span>Alerts</span>
+                <BellRing className="h-4 w-4 text-rose-300" />
+              </div>
+              <p className="mt-2 text-2xl font-semibold text-white">{activeAlerts.length}</p>
             </div>
           </div>
         </div>
@@ -144,6 +157,40 @@ export function ControlPanel() {
           ) : (
             <div className="rounded-2xl border border-white/10 bg-white/5 p-6 text-center text-sm text-white/50">
               No auxiliary operators registered.
+            </div>
+          )}
+        </div>
+      </section>
+
+      <section className="rounded-3xl border border-white/10 bg-white/5 p-6 shadow-[0_20px_60px_-30px_rgba(15,23,42,0.8)]">
+        <div className="flex items-center justify-between">
+          <div>
+            <p className="text-xs uppercase tracking-[0.3em] text-white/50">
+              Mission Capsules
+            </p>
+            <h3 className="mt-1 text-lg font-semibold text-white">Active Operations</h3>
+          </div>
+          <Rocket className="h-5 w-5 text-emerald-300" />
+        </div>
+        <div className="mt-4 space-y-3 text-sm">
+          {liveMissions.length > 0 ? (
+            liveMissions.slice(0, 3).map((mission) => (
+              <div
+                key={mission.id}
+                className="rounded-2xl border border-white/10 bg-white/5 p-3"
+              >
+                <div className="flex items-center justify-between text-xs uppercase tracking-[0.3em] text-white/50">
+                  <span>{mission.title}</span>
+                  <span className="rounded-full border border-emerald-400/40 bg-emerald-500/10 px-2 py-1 text-emerald-200">
+                    {mission.status.replace('-', ' ')}
+                  </span>
+                </div>
+                <p className="mt-2 text-sm text-white/60">{mission.objective}</p>
+              </div>
+            ))
+          ) : (
+            <div className="rounded-2xl border border-white/10 bg-white/5 p-6 text-center text-sm text-white/50">
+              No active operations queued.
             </div>
           )}
         </div>

--- a/src/components/interface/OperationsBoard.tsx
+++ b/src/components/interface/OperationsBoard.tsx
@@ -1,0 +1,380 @@
+import { FormEvent, useMemo, useState } from 'react';
+import {
+  AlertCircle,
+  BellRing,
+  CalendarClock,
+  CheckCircle2,
+  Circle,
+  FileLock,
+  PauseCircle,
+  PlayCircle,
+  TimerReset,
+} from 'lucide-react';
+import {
+  NotificationItem,
+  NotificationPriority,
+  useNotificationStore,
+} from '../../store/notificationStore';
+import { MissionStatus, useMissionStore } from '../../store/missionStore';
+import { TransferStatus, useTransferStore } from '../../store/transferStore';
+
+const priorityStyles: Record<NotificationPriority, string> = {
+  high: 'border-rose-400/40 bg-rose-500/10 text-rose-200',
+  medium: 'border-amber-400/40 bg-amber-500/10 text-amber-200',
+  low: 'border-sky-400/40 bg-sky-500/10 text-sky-200',
+};
+
+const statusCopy: Record<MissionStatus, string> = {
+  planning: 'Planning',
+  queued: 'Queued',
+  'in-progress': 'In Progress',
+  completed: 'Completed',
+};
+
+const statusAccent: Record<MissionStatus, string> = {
+  planning: 'border-sky-400/40 bg-sky-500/10 text-sky-200',
+  queued: 'border-amber-400/40 bg-amber-500/10 text-amber-200',
+  'in-progress': 'border-emerald-400/40 bg-emerald-500/10 text-emerald-200',
+  completed: 'border-slate-400/40 bg-slate-500/10 text-slate-200',
+};
+
+const transferStatusCopy: Record<TransferStatus, string> = {
+  queued: 'Queued',
+  transmitting: 'Transmitting',
+  verifying: 'Verifying',
+  complete: 'Complete',
+};
+
+function NotificationCard({ notification }: { notification: NotificationItem }) {
+  const acknowledge = useNotificationStore((state) => state.acknowledgeNotification);
+  const snooze = useNotificationStore((state) => state.snoozeNotification);
+
+  const minutesUntil = notification.snoozedUntil
+    ? Math.max(0, Math.round((notification.snoozedUntil - Date.now()) / 60000))
+    : null;
+
+  return (
+    <div className="space-y-3 rounded-2xl border border-white/10 bg-white/5 p-4">
+      <div className="flex items-center justify-between">
+        <div className={`rounded-full border px-3 py-1 text-xs uppercase tracking-[0.3em] ${priorityStyles[notification.priority]}`}>
+          {notification.priority === 'high'
+            ? 'Critical'
+            : notification.priority === 'medium'
+            ? 'Warning'
+            : 'Info'}
+        </div>
+        <span className="text-xs text-white/40">
+          {new Date(notification.createdAt).toLocaleTimeString([], {
+            hour: '2-digit',
+            minute: '2-digit',
+          })}
+        </span>
+      </div>
+      <div>
+        <p className="text-sm font-semibold text-white">{notification.title}</p>
+        <p className="mt-1 text-sm text-white/60">{notification.message}</p>
+      </div>
+      <div className="flex flex-wrap items-center gap-2 text-xs">
+        <button
+          onClick={() => acknowledge(notification.id)}
+          className="rounded-lg border border-emerald-400/40 bg-emerald-500/10 px-3 py-2 uppercase tracking-[0.3em] text-emerald-200 transition hover:bg-emerald-500/20"
+        >
+          Acknowledge
+        </button>
+        <button
+          onClick={() => snooze(notification.id, 15)}
+          className="rounded-lg border border-white/10 bg-white/10 px-3 py-2 uppercase tracking-[0.3em] text-white/60 transition hover:bg-white/20"
+        >
+          Snooze 15m
+        </button>
+        {minutesUntil !== null && (
+          <span className="ml-auto rounded-full border border-white/10 px-3 py-1 text-white/40">
+            Re-arming in {minutesUntil}m
+          </span>
+        )}
+      </div>
+    </div>
+  );
+}
+
+function MissionForm() {
+  const addMission = useMissionStore((state) => state.addMission);
+  const [title, setTitle] = useState('');
+  const [objective, setObjective] = useState('');
+  const [windowHours, setWindowHours] = useState(2);
+  const [encryptionLevel, setEncryptionLevel] = useState<'amber' | 'crimson' | 'onyx'>('crimson');
+
+  const handleSubmit = (event: FormEvent) => {
+    event.preventDefault();
+    if (!title.trim() || !objective.trim()) {
+      return;
+    }
+
+    const now = Date.now();
+    addMission({
+      title: title.trim(),
+      objective: objective.trim(),
+      windowStart: now,
+      windowEnd: now + windowHours * 60 * 60 * 1000,
+      assignedTo: ['You'],
+      encryptionLevel,
+      status: 'planning',
+    });
+
+    setTitle('');
+    setObjective('');
+    setWindowHours(2);
+  };
+
+  return (
+    <form
+      onSubmit={handleSubmit}
+      className="space-y-3 rounded-2xl border border-white/10 bg-white/5 p-4"
+    >
+      <div className="flex items-center justify-between text-xs uppercase tracking-[0.3em] text-white/50">
+        <span>New Mission Capsule</span>
+        <CalendarClock className="h-4 w-4 text-sky-300" />
+      </div>
+      <input
+        value={title}
+        onChange={(event) => setTitle(event.target.value)}
+        placeholder="Operation codename"
+        className="w-full rounded-xl border border-white/10 bg-slate-950/60 px-3 py-2 text-sm text-white placeholder:text-white/40 focus:border-white/30 focus:outline-none"
+      />
+      <textarea
+        value={objective}
+        onChange={(event) => setObjective(event.target.value)}
+        placeholder="Outline objectives and constraints..."
+        className="h-20 w-full rounded-xl border border-white/10 bg-slate-950/60 px-3 py-2 text-sm text-white placeholder:text-white/40 focus:border-white/30 focus:outline-none"
+      />
+      <div className="grid gap-3 sm:grid-cols-3">
+        <label className="space-y-1 text-xs uppercase tracking-[0.3em] text-white/50">
+          <span>Window (hrs)</span>
+          <input
+            type="number"
+            min={1}
+            max={24}
+            value={windowHours}
+            onChange={(event) => setWindowHours(Number(event.target.value))}
+            className="w-full rounded-xl border border-white/10 bg-slate-950/60 px-3 py-2 text-sm text-white focus:border-white/30 focus:outline-none"
+          />
+        </label>
+        <label className="space-y-1 text-xs uppercase tracking-[0.3em] text-white/50">
+          <span>Encryption</span>
+          <select
+            value={encryptionLevel}
+            onChange={(event) => setEncryptionLevel(event.target.value as 'amber' | 'crimson' | 'onyx')}
+            className="w-full rounded-xl border border-white/10 bg-slate-950/60 px-3 py-2 text-sm text-white focus:border-white/30 focus:outline-none"
+          >
+            <option value="amber">Amber</option>
+            <option value="crimson">Crimson</option>
+            <option value="onyx">Onyx</option>
+          </select>
+        </label>
+        <div className="flex items-end">
+          <button
+            type="submit"
+            className="w-full rounded-xl border border-emerald-400/40 bg-emerald-500/10 px-4 py-2 text-xs uppercase tracking-[0.3em] text-emerald-300 transition hover:bg-emerald-500/20"
+          >
+            Prime Mission
+          </button>
+        </div>
+      </div>
+    </form>
+  );
+}
+
+export function OperationsBoard() {
+  const activeNotifications = useNotificationStore((state) => state.getActiveNotifications());
+  const missions = useMissionStore((state) => state.missions);
+  const updateMissionStatus = useMissionStore((state) => state.updateMissionStatus);
+  const transfers = useTransferStore((state) => state.transfers);
+
+  const activeMissions = useMemo(
+    () => missions.filter((mission) => mission.status !== 'completed'),
+    [missions]
+  );
+
+  const recentCompleted = useMemo(
+    () => missions.filter((mission) => mission.status === 'completed').slice(0, 2),
+    [missions]
+  );
+
+  return (
+    <section className="space-y-6 rounded-3xl border border-white/10 bg-white/5 p-6 shadow-[0_30px_80px_-40px_rgba(15,23,42,0.9)]">
+      <div className="flex flex-wrap items-center gap-3 text-xs uppercase tracking-[0.3em] text-white/50">
+        <span className="rounded-full border border-white/10 px-3 py-1 text-white/60">Operations Board</span>
+        <span className="rounded-full border border-emerald-400/40 bg-emerald-500/10 px-3 py-1 text-emerald-300">
+          Multi-Vector Sync
+        </span>
+      </div>
+
+      <div className="grid gap-4 lg:grid-cols-2">
+        <div className="space-y-4">
+          <div className="flex items-center justify-between text-xs uppercase tracking-[0.3em] text-white/50">
+            <span className="flex items-center gap-2">
+              <BellRing className="h-4 w-4 text-rose-300" /> Alerts
+            </span>
+            <span className="text-white/40">{activeNotifications.length} active</span>
+          </div>
+          {activeNotifications.length > 0 ? (
+            <div className="space-y-3">
+              {activeNotifications.slice(0, 3).map((notification) => (
+                <NotificationCard key={notification.id} notification={notification} />
+              ))}
+            </div>
+          ) : (
+            <div className="flex items-center gap-3 rounded-2xl border border-white/10 bg-white/5 p-4 text-sm text-white/60">
+              <CheckCircle2 className="h-5 w-5 text-emerald-300" />
+              All systems nominal. Awaiting new directives.
+            </div>
+          )}
+        </div>
+
+        <div className="space-y-4">
+          <MissionForm />
+
+          <div className="space-y-3 rounded-2xl border border-white/10 bg-white/5 p-4">
+            <div className="flex items-center justify-between text-xs uppercase tracking-[0.3em] text-white/50">
+              <span className="flex items-center gap-2">
+                <PlayCircle className="h-4 w-4 text-emerald-300" /> Active Missions
+              </span>
+              <span className="text-white/40">{activeMissions.length} live</span>
+            </div>
+            <div className="space-y-3">
+              {activeMissions.length > 0 ? (
+                activeMissions.map((mission) => (
+                  <div
+                    key={mission.id}
+                    className="rounded-2xl border border-white/10 bg-slate-950/60 p-4"
+                  >
+                    <div className="flex flex-wrap items-center gap-2 text-xs uppercase tracking-[0.3em] text-white/40">
+                      <span>{mission.title}</span>
+                      <span className={`rounded-full border px-2 py-1 ${statusAccent[mission.status]}`}>
+                        {statusCopy[mission.status]}
+                      </span>
+                      <span className="rounded-full border border-white/10 px-2 py-1 text-white/50">
+                        {mission.encryptionLevel.toUpperCase()} Shield
+                      </span>
+                    </div>
+                    <p className="mt-2 text-sm text-white/70">{mission.objective}</p>
+                    <div className="mt-3 flex flex-wrap items-center gap-2 text-xs text-white/50">
+                      <span>Window:</span>
+                      <span>
+                        {new Date(mission.windowStart).toLocaleTimeString([], {
+                          hour: '2-digit',
+                          minute: '2-digit',
+                        })}
+                        {' — '}
+                        {new Date(mission.windowEnd).toLocaleTimeString([], {
+                          hour: '2-digit',
+                          minute: '2-digit',
+                        })}
+                      </span>
+                      <span className="ml-auto flex items-center gap-2">
+                        <button
+                          onClick={() => updateMissionStatus(mission.id, 'queued')}
+                          className="rounded-lg border border-white/10 bg-white/10 px-3 py-2 uppercase tracking-[0.3em] text-white/60 transition hover:bg-white/20"
+                        >
+                          Queue
+                        </button>
+                        <button
+                          onClick={() => updateMissionStatus(mission.id, 'in-progress')}
+                          className="rounded-lg border border-emerald-400/40 bg-emerald-500/10 px-3 py-2 uppercase tracking-[0.3em] text-emerald-300 transition hover:bg-emerald-500/20"
+                        >
+                          Launch
+                        </button>
+                        <button
+                          onClick={() => updateMissionStatus(mission.id, 'completed')}
+                          className="rounded-lg border border-white/10 bg-white/10 px-3 py-2 uppercase tracking-[0.3em] text-white/40 transition hover:bg-white/20"
+                        >
+                          Close
+                        </button>
+                      </span>
+                    </div>
+                  </div>
+                ))
+              ) : (
+                <div className="flex items-center gap-3 rounded-2xl border border-white/10 bg-white/5 p-4 text-sm text-white/60">
+                  <PauseCircle className="h-5 w-5 text-white/40" />
+                  No active missions. Queue a new capsule to begin operations.
+                </div>
+              )}
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <div className="grid gap-4 lg:grid-cols-[2fr_1fr]">
+        <div className="space-y-3 rounded-2xl border border-white/10 bg-white/5 p-4">
+          <div className="flex items-center justify-between text-xs uppercase tracking-[0.3em] text-white/50">
+            <span className="flex items-center gap-2">
+              <FileLock className="h-4 w-4 text-fuchsia-300" /> Secure Transfer Queue
+            </span>
+            <span className="text-white/40">{transfers.length} items</span>
+          </div>
+          <div className="space-y-3">
+            {transfers.map((transfer) => (
+              <div key={transfer.id} className="rounded-2xl border border-white/10 bg-slate-950/60 p-4">
+                <div className="flex items-center justify-between text-sm text-white/70">
+                  <span>{transfer.label}</span>
+                  <span className="text-white/40">{transferStatusCopy[transfer.status]}</span>
+                </div>
+                <div className="mt-3 h-2 w-full overflow-hidden rounded-full bg-white/10">
+                  <div
+                    className={`h-full rounded-full ${
+                      transfer.status === 'complete'
+                        ? 'bg-emerald-400'
+                        : transfer.status === 'verifying'
+                        ? 'bg-sky-400'
+                        : 'bg-fuchsia-400'
+                    }`}
+                    style={{ width: `${transfer.progress}%` }}
+                  />
+                </div>
+                <div className="mt-2 flex flex-wrap items-center gap-2 text-xs text-white/40">
+                  <span>{transfer.size}</span>
+                  {transfer.secureHash && (
+                    <span className="flex items-center gap-1">
+                      <TimerReset className="h-3.5 w-3.5" />
+                      {transfer.secureHash}
+                    </span>
+                  )}
+                </div>
+              </div>
+            ))}
+          </div>
+        </div>
+
+        <div className="space-y-3 rounded-2xl border border-white/10 bg-white/5 p-4">
+          <div className="flex items-center justify-between text-xs uppercase tracking-[0.3em] text-white/50">
+            <span className="flex items-center gap-2">
+              <Circle className="h-4 w-4 text-sky-300" /> Completed Capsules
+            </span>
+            <span className="text-white/40">{recentCompleted.length}</span>
+          </div>
+          <div className="space-y-3">
+            {recentCompleted.length > 0 ? (
+              recentCompleted.map((mission) => (
+                <div key={mission.id} className="rounded-2xl border border-white/10 bg-slate-950/60 p-4">
+                  <div className="flex items-center justify-between text-sm text-white/70">
+                    <span>{mission.title}</span>
+                    <span className="rounded-full border border-emerald-400/40 bg-emerald-500/10 px-2 py-1 text-xs uppercase tracking-[0.3em] text-emerald-300">
+                      Archived
+                    </span>
+                  </div>
+                  <p className="mt-2 text-xs text-white/50">{mission.objective}</p>
+                </div>
+              ))
+            ) : (
+              <div className="flex items-center gap-3 rounded-2xl border border-white/10 bg-white/5 p-4 text-sm text-white/60">
+                <AlertCircle className="h-5 w-5 text-white/40" />
+                Awaiting completed capsules.
+              </div>
+            )}
+          </div>
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/src/store/missionStore.ts
+++ b/src/store/missionStore.ts
@@ -1,0 +1,85 @@
+import { create } from 'zustand';
+
+export type MissionStatus = 'planning' | 'queued' | 'in-progress' | 'completed';
+
+export interface Mission {
+  id: string;
+  title: string;
+  objective: string;
+  windowStart: number;
+  windowEnd: number;
+  status: MissionStatus;
+  assignedTo: string[];
+  encryptionLevel: 'amber' | 'crimson' | 'onyx';
+}
+
+interface MissionState {
+  missions: Mission[];
+  addMission: (mission: Omit<Mission, 'id' | 'status'> & { status?: MissionStatus }) => void;
+  updateMissionStatus: (missionId: string, status: MissionStatus) => void;
+  getActiveMissions: () => Mission[];
+}
+
+const hoursFromNow = (hours: number) => Date.now() + hours * 60 * 60 * 1000;
+
+export const useMissionStore = create<MissionState>((set, get) => ({
+  missions: [
+    {
+      id: 'm-1',
+      title: 'Spectral Sweep',
+      objective: 'Deploy orbital listeners to capture stray transmissions from Sector Theta.',
+      windowStart: hoursFromNow(-2),
+      windowEnd: hoursFromNow(4),
+      status: 'in-progress',
+      assignedTo: ['Nova Ruiz', 'Adian Holt'],
+      encryptionLevel: 'onyx',
+    },
+    {
+      id: 'm-2',
+      title: 'Beacon Calibration',
+      objective: 'Recalibrate ground beacons and push updated spectrum keys to all operators.',
+      windowStart: hoursFromNow(1),
+      windowEnd: hoursFromNow(6),
+      status: 'queued',
+      assignedTo: ['Mira West'],
+      encryptionLevel: 'crimson',
+    },
+    {
+      id: 'm-3',
+      title: 'Vault Compression',
+      objective: 'Compact cold storage archives and redistribute redundant shards.',
+      windowStart: hoursFromNow(-5),
+      windowEnd: hoursFromNow(-1),
+      status: 'completed',
+      assignedTo: ['Systems Collective'],
+      encryptionLevel: 'amber',
+    },
+  ],
+
+  addMission: (mission) => {
+    const now = Date.now();
+    const newMission: Mission = {
+      id: `m-${now}`,
+      status: mission.status ?? 'planning',
+      ...mission,
+    };
+
+    set((state) => ({
+      missions: [newMission, ...state.missions],
+    }));
+  },
+
+  updateMissionStatus: (missionId, status) => {
+    set((state) => ({
+      missions: state.missions.map((mission) =>
+        mission.id === missionId ? { ...mission, status } : mission
+      ),
+    }));
+  },
+
+  getActiveMissions: () => {
+    return get()
+      .missions.filter((mission) => mission.status !== 'completed')
+      .sort((a, b) => a.windowStart - b.windowStart);
+  },
+}));

--- a/src/store/notificationStore.ts
+++ b/src/store/notificationStore.ts
@@ -1,0 +1,100 @@
+import { create } from 'zustand';
+
+export type NotificationPriority = 'low' | 'medium' | 'high';
+
+export interface NotificationItem {
+  id: string;
+  title: string;
+  message: string;
+  priority: NotificationPriority;
+  createdAt: number;
+  acknowledged: boolean;
+  snoozedUntil?: number;
+}
+
+interface NotificationState {
+  notifications: NotificationItem[];
+  addNotification: (notification: Omit<NotificationItem, 'id' | 'createdAt' | 'acknowledged'>) => void;
+  acknowledgeNotification: (id: string) => void;
+  snoozeNotification: (id: string, minutes: number) => void;
+  getActiveNotifications: () => NotificationItem[];
+}
+
+export const useNotificationStore = create<NotificationState>((set, get) => ({
+  notifications: [
+    {
+      id: 'n-1',
+      title: 'Vault Sync Drift',
+      message: 'Node Kappa is 2 minutes out of sync. Schedule recalibration.',
+      priority: 'high',
+      createdAt: Date.now() - 1000 * 60 * 5,
+      acknowledged: false,
+    },
+    {
+      id: 'n-2',
+      title: 'Signal Integrity',
+      message: 'Atmospheric interference detected over Sector 7.',
+      priority: 'medium',
+      createdAt: Date.now() - 1000 * 60 * 20,
+      acknowledged: false,
+    },
+    {
+      id: 'n-3',
+      title: 'Archive Notice',
+      message: 'Auto-pruning cold storage in 12 hours.',
+      priority: 'low',
+      createdAt: Date.now() - 1000 * 60 * 40,
+      acknowledged: false,
+    },
+  ],
+
+  addNotification: (notification) => {
+    const now = Date.now();
+    const newNotification: NotificationItem = {
+      id: `n-${now}`,
+      createdAt: now,
+      acknowledged: false,
+      ...notification,
+    };
+
+    set((state) => ({
+      notifications: [newNotification, ...state.notifications],
+    }));
+  },
+
+  acknowledgeNotification: (id) => {
+    set((state) => ({
+      notifications: state.notifications.map((notification) =>
+        notification.id === id
+          ? { ...notification, acknowledged: true, snoozedUntil: undefined }
+          : notification
+      ),
+    }));
+  },
+
+  snoozeNotification: (id, minutes) => {
+    const snoozeUntil = Date.now() + minutes * 60 * 1000;
+    set((state) => ({
+      notifications: state.notifications.map((notification) =>
+        notification.id === id
+          ? { ...notification, snoozedUntil: snoozeUntil, acknowledged: false }
+          : notification
+      ),
+    }));
+  },
+
+  getActiveNotifications: () => {
+    const now = Date.now();
+    return get()
+      .notifications.filter((notification) => {
+        if (notification.acknowledged) {
+          return false;
+        }
+        if (notification.snoozedUntil && notification.snoozedUntil > now) {
+          return false;
+        }
+        return true;
+      })
+      .sort((a, b) => b.createdAt - a.createdAt);
+  },
+}));

--- a/src/store/transferStore.ts
+++ b/src/store/transferStore.ts
@@ -1,0 +1,76 @@
+import { create } from 'zustand';
+
+export type TransferStatus = 'queued' | 'transmitting' | 'verifying' | 'complete';
+
+export interface TransferJob {
+  id: string;
+  label: string;
+  size: string;
+  status: TransferStatus;
+  progress: number;
+  secureHash?: string;
+}
+
+interface TransferState {
+  transfers: TransferJob[];
+  startTransfer: (job: Omit<TransferJob, 'status' | 'progress'>) => void;
+  updateTransferProgress: (id: string, progress: number, status?: TransferStatus) => void;
+}
+
+export const useTransferStore = create<TransferState>((set) => ({
+  transfers: [
+    {
+      id: 't-1',
+      label: 'Cryptex Archive // 44MB',
+      size: '44 MB',
+      status: 'transmitting',
+      progress: 68,
+      secureHash: 'd2f9:aa17:bb34',
+    },
+    {
+      id: 't-2',
+      label: 'Spectral Logs // 1.4GB',
+      size: '1.4 GB',
+      status: 'queued',
+      progress: 0,
+    },
+    {
+      id: 't-3',
+      label: 'Presence Mesh Delta // 512KB',
+      size: '512 KB',
+      status: 'verifying',
+      progress: 92,
+      secureHash: '99ab:8712:2210',
+    },
+  ],
+
+  startTransfer: (job) => {
+    set((state) => ({
+      transfers: [
+        {
+          id: job.id,
+          label: job.label,
+          size: job.size,
+          secureHash: job.secureHash,
+          status: 'queued',
+          progress: 0,
+        },
+        ...state.transfers,
+      ],
+    }));
+  },
+
+  updateTransferProgress: (id, progress, status) => {
+    set((state) => ({
+      transfers: state.transfers.map((transfer) =>
+        transfer.id === id
+          ? {
+              ...transfer,
+              progress,
+              status: status ?? transfer.status,
+            }
+          : transfer
+      ),
+    }));
+  },
+}));


### PR DESCRIPTION
## Summary
- add a mission-aware operations board featuring alert handling, mission planning, and transfer monitoring
- extend the control lattice panel with live alert counts and mission capsule summaries
- introduce zustand stores for notifications, missions, and transfer queues to back the new UI flows

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e2e5c5e3488323a0cc98a223940397